### PR TITLE
Named arguments; rewrite extract_prediction(); extract train predictions from already fitted models

### DIFF
--- a/R/double_ml_iivm.R
+++ b/R/double_ml_iivm.R
@@ -198,26 +198,34 @@ private = list(
 
     m_hat = dml_cv_predict(self$learner$ml_m, c(self$data$x_cols, self$data$other_treat_cols), self$data$z_cols, 
                            self$data$data_model, nuisance_id = "nuis_m",  
-                           smpls, self$get_params("ml_m"), return_train_preds = FALSE, 
-                           learner_class = private$learner_class$ml_m, private$fold_specific_params)
+                           smpls = smpls, est_params = self$get_params("ml_m"),
+                           return_train_preds = FALSE, 
+                           learner_class = private$learner_class$ml_m,
+                           fold_specific_params = private$fold_specific_params)
     
     g0_hat = dml_cv_predict(self$learner$ml_g, c(self$data$x_cols, self$data$other_treat_cols), self$data$y_col, 
                             self$data$data_model, nuisance_id = "nuis_g0",  
-                            cond_smpls$smpls_0, self$get_params("ml_g0"), return_train_preds = FALSE, 
-                            learner_class = private$learner_class$ml_g, private$fold_specific_params)
+                            smpls = cond_smpls$smpls_0, est_params = self$get_params("ml_g0"),
+                            return_train_preds = FALSE, 
+                            learner_class = private$learner_class$ml_g,
+                            fold_specific_params = private$fold_specific_params)
     
     g1_hat = dml_cv_predict(self$learner$ml_g, c(self$data$x_cols, self$data$other_treat_cols), self$data$y_col, 
                             self$data$data_model, nuisance_id = "nuis_g1",  
-                            cond_smpls$smpls_1, self$get_params("ml_g1"), return_train_preds = FALSE, 
-                            learner_class = private$learner_class$ml_g, private$fold_specific_params)
+                            smpls = cond_smpls$smpls_1, est_params = self$get_params("ml_g1"),
+                            return_train_preds = FALSE, 
+                            learner_class = private$learner_class$ml_g,
+                            fold_specific_params = private$fold_specific_params)
     
     if (self$subgroups$always_takers == FALSE){
       r0_hat = rep(0, self$data$n_obs)
     } else {
       r0_hat = dml_cv_predict(self$learner$ml_r, c(self$data$x_cols, self$data$other_treat_cols), self$data$treat_col, 
                               self$data$data_model, nuisance_id = "nuis_r0",  
-                              cond_smpls$smpls_0, self$get_params("ml_r0"), return_train_preds = FALSE, 
-                              learner_class = private$learner_class$ml_r, private$fold_specific_params)
+                              smpls = cond_smpls$smpls_0, est_params = self$get_params("ml_r0"),
+                              return_train_preds = FALSE, 
+                              learner_class = private$learner_class$ml_r,
+                              fold_specific_params = private$fold_specific_params)
     }
       
     if (self$subgroups$never_takers == FALSE){
@@ -225,8 +233,10 @@ private = list(
     } else {
       r1_hat = dml_cv_predict(self$learner$ml_r, c(self$data$x_cols, self$data$other_treat_cols), self$data$treat_col, 
                               self$data$data_model, nuisance_id = "nuis_r1",  
-                              cond_smpls$smpls_1, self$get_params("ml_r1"), return_train_preds = FALSE, 
-                              learner_class = private$learner_class$ml_r, private$fold_specific_params)
+                              smpls = cond_smpls$smpls_1, est_params = self$get_params("ml_r1"),
+                              return_train_preds = FALSE, 
+                              learner_class = private$learner_class$ml_r,
+                              fold_specific_params = private$fold_specific_params)
     }
     
     # compute residuals

--- a/R/double_ml_irm.R
+++ b/R/double_ml_irm.R
@@ -164,19 +164,25 @@ private = list(
     
     m_hat = dml_cv_predict(self$learner$ml_m, c(self$data$x_cols, self$data$other_treat_cols), self$data$treat_col, 
                            self$data$data_model, nuisance_id = "nuis_m",  
-                           smpls, self$get_params("ml_m"), return_train_preds = FALSE, 
-                           learner_class = private$learner_class$ml_m, private$fold_specific_params)
+                           smpls = smpls, est_params = self$get_params("ml_m"),
+                           return_train_preds = FALSE, 
+                           learner_class = private$learner_class$ml_m,
+                           fold_specific_params = private$fold_specific_params)
           
     g0_hat = dml_cv_predict(self$learner$ml_g, c(self$data$x_cols, self$data$other_treat_cols), self$data$y_col, 
                             self$data$data_model, nuisance_id = "nuis_g0",  
-                            cond_smpls$smpls_0, self$get_params("ml_g0"), return_train_preds = FALSE, 
-                            learner_class = private$learner_class$ml_g, private$fold_specific_params)
+                            smpls = cond_smpls$smpls_0, est_params = self$get_params("ml_g0"),
+                            return_train_preds = FALSE, 
+                            learner_class = private$learner_class$ml_g,
+                            fold_specific_params = private$fold_specific_params)
     
     if (self$score == "ATE" | is.function(self$score)) {
       g1_hat = dml_cv_predict(self$learner$ml_g, c(self$data$x_cols, self$data$other_treat_cols), self$data$y_col, 
                              self$data$data_model, nuisance_id = "nuis_g1",  
-                             cond_smpls$smpls_1, self$get_params("ml_g1"), return_train_preds = FALSE, 
-                             learner_class = private$learner_class$ml_g, private$fold_specific_params)
+                             smpls = cond_smpls$smpls_1, est_params = self$get_params("ml_g1"),
+                             return_train_preds = FALSE, 
+                             learner_class = private$learner_class$ml_g,
+                             fold_specific_params = private$fold_specific_params)
     }
     
     d = self$data$data_model[[self$data$treat_col]]

--- a/R/double_ml_pliv.R
+++ b/R/double_ml_pliv.R
@@ -447,8 +447,7 @@ private = list(
     resampling_m_on_train = lapply(task_m, function(x) rsmp("insample")$instantiate(x))
     r_m_on_train = lapply(1:length(data_tune_list), function(x) 
                                         resample(task_m[[x]], ml_m[[x]], resampling_m_on_train[[x]], store_models = TRUE))
-    m_hat_on_train = lapply(r_m_on_train, function(x) extract_prediction(x, private$learner_class$ml_m, 
-                                                                          return_train_preds = TRUE)[[1]])
+    m_hat_on_train = extract_prediction(r_m_on_train, private$learner_class$ml_m, self$data$n_obs, return_train_preds = TRUE)
     data_aux_list = lapply(1:length(data_tune_list), function(x) 
                                               data.table(data_tune_list[[x]], "m_hat_on_train" = m_hat_on_train[[x]]))
     

--- a/R/double_ml_pliv.R
+++ b/R/double_ml_pliv.R
@@ -199,25 +199,33 @@ private = list(
     
     g_hat = dml_cv_predict(self$learner$ml_g, c(self$data$x_cols, self$data$other_treat_cols), self$data$y_col, 
                            self$data$data_model, nuisance_id = "nuis_g",  
-                           smpls, self$get_params("ml_g"), return_train_preds = FALSE, 
-                           learner_class = private$learner_class$ml_g, private$fold_specific_params)
+                           smpls = smpls, est_params = self$get_params("ml_g"),
+                           return_train_preds = FALSE, 
+                           learner_class = private$learner_class$ml_g,
+                           fold_specific_params = private$fold_specific_params)
       
     r_hat = dml_cv_predict(self$learner$ml_r, c(self$data$x_cols, self$data$other_treat_cols), self$data$treat_col, 
                            self$data$data_model, nuisance_id = "nuis_r",  
-                           smpls, self$get_params("ml_r"), return_train_preds = FALSE, 
-                           learner_class = private$learner_class$ml_r, private$fold_specific_params)
+                           smpls = smpls, est_params = self$get_params("ml_r"),
+                           return_train_preds = FALSE, 
+                           learner_class = private$learner_class$ml_r,
+                           fold_specific_params = private$fold_specific_params)
     
     if (self$data$n_instr == 1) {
       m_hat = dml_cv_predict(self$learner$ml_m, c(self$data$x_cols, self$data$other_treat_cols), self$data$z_cols, 
                              self$data$data_model, nuisance_id = "nuis_m",  
-                             smpls, self$get_params("ml_m"), return_train_preds = FALSE, 
-                             learner_class = private$learner_class$ml_m, private$fold_specific_params)
+                             smpls = smpls, est_params = self$get_params("ml_m"),
+                             return_train_preds = FALSE, 
+                             learner_class = private$learner_class$ml_m,
+                             fold_specific_params = private$fold_specific_params)
     } else {
       m_hat = do.call(cbind, lapply(self$data$z_cols, function(x) 
                                         dml_cv_predict(self$learner$ml_m, c(self$data$x_cols, self$data$other_treat_cols),  x, 
                                                        self$data$data_model, nuisance_id = "nuis_m",  
-                                                       smpls, self$get_params(paste0("ml_m_", x)), return_train_preds = FALSE, 
-                                                       learner_class = private$learner_class$ml_m, private$fold_specific_params)))
+                                                       smpls = smpls, est_params = self$get_params(paste0("ml_m_", x)),
+                                                       return_train_preds = FALSE, 
+                                                       learner_class = private$learner_class$ml_m,
+                                                       fold_specific_params = private$fold_specific_params)))
     }
     
     d = self$data$data_model[[self$data$treat_col]]
@@ -276,24 +284,29 @@ private = list(
     
     g_hat = dml_cv_predict(self$learner$ml_g, c(self$data$x_cols, self$data$other_treat_cols), self$data$y_col, 
                            self$data$data_model, nuisance_id = "nuis_g",  
-                           smpls, self$get_params("ml_g"), return_train_preds = FALSE, 
-                           learner_class = private$learner_class$ml_g, private$fold_specific_params)
+                           smpls = smpls, est_params = self$get_params("ml_g"),
+                           return_train_preds = FALSE, 
+                           learner_class = private$learner_class$ml_g,
+                           fold_specific_params = private$fold_specific_params)
       
     m_hat_list = dml_cv_predict(self$learner$ml_m, c(self$data$x_cols, self$data$other_treat_cols, self$data$z_cols), 
                                 self$data$treat_col, 
                                 self$data$data_model, nuisance_id = "nuis_m",  
-                                smpls, self$get_params("ml_m"), return_train_preds = TRUE, 
-                                learner_class = private$learner_class$ml_m, private$fold_specific_params)
+                                smpls = smpls, est_params = self$get_params("ml_m"),
+                                return_train_preds = TRUE, 
+                                learner_class = private$learner_class$ml_m,
+                                fold_specific_params = private$fold_specific_params)
     m_hat = m_hat_list$preds
     data_aux_list = lapply(m_hat_list$train_preds, function(x)
                                                       data.table(self$data$data_model, "m_hat_on_train" = x))
     
     m_hat_tilde = dml_cv_predict(self$learner$ml_r, c(self$data$x_cols, self$data$other_treat_cols), 
                                  "m_hat_on_train", 
-                                  data_aux_list, nuisance_id = "nuis_r",  
-                                  smpls, self$get_params("ml_r"), return_train_preds = FALSE, 
-                                  learner_class = private$learner_class$ml_r, 
-                                  private$fold_specific_params)
+                                 data_aux_list, nuisance_id = "nuis_r",  
+                                 smpls = smpls, est_params = self$get_params("ml_r"),
+                                 return_train_preds = FALSE, 
+                                 learner_class = private$learner_class$ml_r, 
+                                 fold_specific_params = private$fold_specific_params)
     
     d = self$data$data_model[[self$data$treat_col]]
     y = self$data$data_model[[self$data$y_col]]
@@ -321,8 +334,10 @@ private = list(
     r_hat = dml_cv_predict(self$learner$ml_r, 
                            c(self$data$x_cols, self$data$other_treat_cols, self$data$z_cols), self$data$treat_col, 
                            self$data$data_model, nuisance_id = "nuis_r",  
-                           smpls, self$get_params("ml_r"), return_train_preds = FALSE, 
-                           learner_class = private$learner_class$ml_r, private$fold_specific_params)
+                           smpls = smpls, est_params = self$get_params("ml_r"),
+                           return_train_preds = FALSE, 
+                           learner_class = private$learner_class$ml_r,
+                           fold_specific_params = private$fold_specific_params)
     
     d = self$data$data_model[[self$data$treat_col]]
     y = self$data$data_model[[self$data$y_col]]

--- a/R/double_ml_plr.R
+++ b/R/double_ml_plr.R
@@ -138,13 +138,17 @@ private = list(
   ml_nuisance_and_score_elements = function(smpls, ...) {
     g_hat = dml_cv_predict(self$learner$ml_g, c(self$data$x_cols, self$data$other_treat_cols), self$data$y_col, 
                            self$data$data_model, nuisance_id = "nuis_g",  
-                           smpls, self$get_params("ml_g"), return_train_preds = FALSE, 
-                           learner_class = private$learner_class$ml_g, private$fold_specific_params)
+                           smpls = smpls, est_params = self$get_params("ml_g"),
+                           return_train_preds = FALSE, 
+                           learner_class = private$learner_class$ml_g,
+                           fold_specific_params = private$fold_specific_params)
     
     m_hat = dml_cv_predict(self$learner$ml_m, c(self$data$x_cols, self$data$other_treat_cols), self$data$treat_col,
                            self$data$data_model, nuisance_id = "nuis_m", 
-                           smpls, self$get_params("ml_m"), return_train_preds = FALSE, 
-                           learner_class = private$learner_class$ml_m, private$fold_specific_params)
+                           smpls = smpls, est_params = self$get_params("ml_m"),
+                           return_train_preds = FALSE,
+                           learner_class = private$learner_class$ml_m,
+                           fold_specific_params = private$fold_specific_params)
     
     d = self$data$data_model[[self$data$treat_col]]
     y = self$data$data_model[[self$data$y_col]]

--- a/R/helper.R
+++ b/R/helper.R
@@ -25,7 +25,9 @@ dml_cv_predict = function(learner, X_cols, y_col,
                                                                smpls$test_ids)
       resampling_pred = resample(task_pred, ml_learner, resampling_smpls, store_models = TRUE)
       preds = extract_prediction(resampling_pred, learner_class, n_obs)
-      if (return_train_preds) train_preds = extract_prediction(resampling_pred, learner_class, n_obs, return_train_preds = TRUE)
+      if (return_train_preds) {
+        train_preds = extract_prediction(resampling_pred, learner_class, n_obs, return_train_preds = TRUE)
+      }
     } else {
       # learners initiated according to fold-specific learners, proceed foldwise
       ml_learners = lapply(est_params, function(x) initiate_learner(learner, learner_class, x, return_train_preds))
@@ -37,7 +39,9 @@ dml_cv_predict = function(learner, X_cols, y_col,
                                                                            resampling_smpls[[x]], store_models = TRUE))
       
       preds = extract_prediction(resampling_pred, learner_class, n_obs)
-      if (return_train_preds) train_preds = extract_prediction(resampling_pred, learner_class, n_obs, return_train_preds = TRUE)
+      if (return_train_preds) {
+        train_preds = extract_prediction(resampling_pred, learner_class, n_obs, return_train_preds = TRUE)
+      }
     }
   } else {
     n_obs = nrow(data_model[[1]])
@@ -109,7 +113,6 @@ extract_prediction = function(obj_resampling, learner_class, n_obs, return_train
   } else if (learner_class == "LearnerClassif") {
     resp_name = "prob.1"
   }
-  
   
   if (return_train_preds) {
     if (checkmate::testR6(obj_resampling, classes='ResampleResult')) {


### PR DESCRIPTION
- Prevent using positional and named argument in a mixed order
- Rewrite `extract_prediction()` to get less complex
- Extract the train predictions (if needed) from the same fitted models as the test predictions