### PR TITLE
 Provide an option to store & export the first-stage predictions

### DIFF
--- a/R/double_ml.R
+++ b/R/double_ml.R
@@ -77,6 +77,10 @@ DoubleML = R6Class("DoubleML", public = list(
   #' Value of the score function component \eqn{\psi_b(W;\eta)} after calling `fit()`. 
   psi_b = NULL, 
   
+  #' @field predictions (`array()`) \cr
+  #' Predictions of the nuisance models after calling `fit(store_predictions=TRUE)`. 
+  predictions = NULL,
+  
   #' @field pval (`numeric()`) \cr
   #' p-values for the causal parameter(s) after calling `fit()`. 
   pval = NULL, 
@@ -149,8 +153,14 @@ DoubleML = R6Class("DoubleML", public = list(
   #' @description 
   #' Estimate DoubleML models. 
   #' 
+  #' @param store_predictions (`logical(1)`) \cr
+  #' Indicates whether the predictions for the nuisance functions should be be stored in field `predictions`. Default is `FALSE`.
+  #' 
   #' @return self
-  fit = function() {
+  fit = function(store_predictions=FALSE) {
+    if (store_predictions) {
+      private$initialize_predictions()
+    }
     
     # TODO: insert check for tuned params
     for (i_rep in 1:self$n_rep) {
@@ -164,9 +174,12 @@ DoubleML = R6Class("DoubleML", public = list(
         }
         
         # ml estimation of nuisance models and computation of psi elements
-        psis = private$ml_nuisance_and_score_elements(private$get__smpls())
-        private$set__psi_a(psis$psi_a)
-        private$set__psi_b(psis$psi_b)
+        res = private$ml_nuisance_and_score_elements(private$get__smpls())
+        private$set__psi_a(res$psi_a)
+        private$set__psi_b(res$psi_b)
+        if (store_predictions) {
+          private$store_predictions(res$preds)
+        }
         
         # estimate the causal parameter
         coef = private$est_causal_pars()
@@ -866,6 +879,17 @@ private = list(
     private$n_rep_boot = n_rep_boot
     self$boot_coef = array(NA, dim=c(self$data$n_treat, n_rep_boot * self$n_rep))
     self$boot_t_stat = array(NA, dim=c(self$data$n_treat, n_rep_boot * self$n_rep))
+  },
+  initialize_predictions = function() {
+    self$predictions = sapply(dml_plr_obj$params_names(),
+                              function(key) array(NA, dim=c(self$data$n_obs, self$n_rep, self$data$n_treat)),
+                              simplify=F)
+  },
+  store_predictions = function(preds) {
+    for (learner in self$params_names())
+    {
+      self$predictions[[learner]][, private$i_rep, private$i_treat] = preds[[learner]]
+    }
   },
   # Comment from python: The private properties with __ always deliver the single treatment, single (cross-fitting) sample subselection
   # The slicing is based on the two properties self._i_treat, the index of the treatment variable, and

--- a/R/double_ml.R
+++ b/R/double_ml.R
@@ -881,14 +881,16 @@ private = list(
     self$boot_t_stat = array(NA, dim=c(self$data$n_treat, n_rep_boot * self$n_rep))
   },
   initialize_predictions = function() {
-    self$predictions = sapply(dml_plr_obj$params_names(),
+    self$predictions = sapply(self$params_names(),
                               function(key) array(NA, dim=c(self$data$n_obs, self$n_rep, self$data$n_treat)),
                               simplify=F)
   },
   store_predictions = function(preds) {
     for (learner in self$params_names())
     {
-      self$predictions[[learner]][, private$i_rep, private$i_treat] = preds[[learner]]
+      if (!is.null(preds[[learner]])) {
+        self$predictions[[learner]][, private$i_rep, private$i_treat] = preds[[learner]]
+      }
     }
   },
   # Comment from python: The private properties with __ always deliver the single treatment, single (cross-fitting) sample subselection

--- a/R/double_ml_iivm.R
+++ b/R/double_ml_iivm.R
@@ -244,8 +244,13 @@ private = list(
     d = self$data$data_model[[self$data$treat_col]]
     y = self$data$data_model[[self$data$y_col]]
 
-    psis = private$score_elements(y, z, d, g0_hat, g1_hat, m_hat, r0_hat, r1_hat, smpls)
-    return(psis)
+    res = private$score_elements(y, z, d, g0_hat, g1_hat, m_hat, r0_hat, r1_hat, smpls)
+    res$preds = list("ml_g0" = g0_hat,
+                     "ml_g1" = g1_hat,
+                     "ml_m" = m_hat,
+                     "ml_r0" = r0_hat,
+                     "ml_r1" = r1_hat)
+    return(res)
   },
   score_elements = function(y, z, d, g0_hat, g1_hat, m_hat, r0_hat, r1_hat, smpls) {
 

--- a/R/double_ml_irm.R
+++ b/R/double_ml_irm.R
@@ -188,8 +188,11 @@ private = list(
     d = self$data$data_model[[self$data$treat_col]]
     y = self$data$data_model[[self$data$y_col]]
     
-    psis = private$score_elements(y, d, g0_hat, g1_hat, m_hat, smpls)
-    return(psis)
+    res = private$score_elements(y, d, g0_hat, g1_hat, m_hat, smpls)
+    res$preds = list("ml_g0" = g0_hat,
+                     "ml_g1" = g1_hat,
+                     "ml_m" = m_hat)
+    return(res)
   },
   score_elements = function(y, d, g0_hat, g1_hat, m_hat, smpls) {
     if (self$score == "ATTE") {

--- a/R/double_ml_irm.R
+++ b/R/double_ml_irm.R
@@ -176,6 +176,7 @@ private = list(
                             learner_class = private$learner_class$ml_g,
                             fold_specific_params = private$fold_specific_params)
     
+    g1_hat = NULL
     if (self$score == "ATE" | is.function(self$score)) {
       g1_hat = dml_cv_predict(self$learner$ml_g, c(self$data$x_cols, self$data$other_treat_cols), self$data$y_col, 
                              self$data$data_model, nuisance_id = "nuis_g1",  

--- a/R/double_ml_pliv.R
+++ b/R/double_ml_pliv.R
@@ -231,8 +231,11 @@ private = list(
     d = self$data$data_model[[self$data$treat_col]]
     y = self$data$data_model[[self$data$y_col]]
     
-    psis = private$score_elements(y, z, d, g_hat, m_hat, r_hat, smpls)
-    return(psis)
+    res = private$score_elements(y, z, d, g_hat, m_hat, r_hat, smpls)
+    res$preds = list("ml_g" = g_hat,
+                     "ml_m" = m_hat,
+                     "ml_r" = r_hat)
+    return(res)
   },
   score_elements = function(y, z, d, g_hat, m_hat, r_hat, smpls) {
     u_hat = y - g_hat
@@ -319,13 +322,16 @@ private = list(
           psi_a = -w_hat * (m_hat - m_hat_tilde)
           psi_b = (m_hat - m_hat_tilde) * u_hat
       }
-      psis = list(psi_a = psi_a,
+      res = list(psi_a = psi_a,
                   psi_b = psi_b)
     } else if (is.function(self$score)) {
       stop("Callable score not implemented for DoubleMLPLIV with partialX=TRUE and partialZ=TRUE.")
-      # psis = self$score(y, d, g_hat, m_hat, m_hat_tilde) 
+      # res = self$score(y, d, g_hat, m_hat, m_hat_tilde) 
     }
-    return(psis)
+    res$preds = list("ml_g" = g_hat,
+                     "ml_m" = m_hat,
+                     "ml_r" = m_hat_tilde)
+    return(res)
   },
   
   ml_nuisance_and_score_elements_partialZ = function(smpls, ...) {
@@ -347,12 +353,13 @@ private = list(
           psi_a = -r_hat* d
           psi_b =  r_hat* y
        }
-      psis = list(psi_a = psi_a, psi_b = psi_b)
+      res = list(psi_a = psi_a, psi_b = psi_b)
     } else if (is.function(self$score)) {
       stop("Callable score not implemented for DoubleMLPLIV with partialX=FALSE and partialZ=TRUE.")
-      # psis = self$score(y, z, d, r_hat)
+      # res = self$score(y, z, d, r_hat)
     }
-    return(psis)
+    res$preds = list("ml_r" = r_hat)
+    return(res)
   },
   
   

--- a/R/double_ml_plr.R
+++ b/R/double_ml_plr.R
@@ -153,8 +153,10 @@ private = list(
     d = self$data$data_model[[self$data$treat_col]]
     y = self$data$data_model[[self$data$y_col]]
     
-    psis = private$score_elements(y, d, g_hat, m_hat, smpls)
-    return(psis)
+    res = private$score_elements(y, d, g_hat, m_hat, smpls)
+    res$preds = list("ml_g" = g_hat,
+                     "ml_m" = m_hat)
+    return(res)
   },
    score_elements = function(y, d, g_hat, m_hat, smpls) {
     v_hat = d - m_hat

--- a/man/DoubleML.Rd
+++ b/man/DoubleML.Rd
@@ -72,6 +72,9 @@ Value of the score function component \eqn{\psi_a(W;\eta)} after calling \code{f
 \item{\code{psi_b}}{(\code{array()}) \cr
 Value of the score function component \eqn{\psi_b(W;\eta)} after calling \code{fit()}.}
 
+\item{\code{predictions}}{(\code{array()}) \cr
+Predictions of the nuisance models after calling \code{fit(store_predictions=TRUE)}.}
+
 \item{\code{pval}}{(\code{numeric()}) \cr
 p-values for the causal parameter(s) after calling \code{fit()}.}
 
@@ -138,9 +141,17 @@ Print DoubleML objects.
 \subsection{Method \code{fit()}}{
 Estimate DoubleML models.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{DoubleML$fit()}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{DoubleML$fit(store_predictions = FALSE)}\if{html}{\out{</div>}}
 }
 
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{store_predictions}}{(\code{logical(1)}) \cr
+Indicates whether the predictions for the nuisance functions should be be stored in field \code{predictions}. Default is \code{FALSE}.}
+}
+\if{html}{\out{</div>}}
+}
 \subsection{Returns}{
 self
 }

--- a/tests/testthat/test-double_ml_plr_export_preds.R
+++ b/tests/testthat/test-double_ml_plr_export_preds.R
@@ -1,0 +1,62 @@
+context("Unit tests for the export of predictions via fit(store_predictions = TRUE); uses PLR")
+
+library("mlr3learners")
+
+lgr::get_logger("mlr3")$set_threshold("warn")
+
+test_cases = expand.grid(g_learner = c('regr.cv_glmnet'),
+                           m_learner = c('regr.cv_glmnet'),
+                           dml_procedure = c('dml2'),
+                           score = c('partialling out'),
+                           i_setting = 1:(length(data_plr)),
+                           stringsAsFactors = FALSE)
+test_cases['test_name'] = apply(test_cases, 1, paste, collapse="_")
+
+patrick::with_parameters_test_that("Unit tests for PLR with classifier for ml_m:",
+                                   .cases = test_cases, {
+   n_folds = 3
+   
+   set.seed(i_setting)
+   Xnames = names(data_plr[[i_setting]])[names(data_plr[[i_setting]]) %in% c("y", "d") == FALSE]
+   data_ml = double_ml_data_from_data_frame(data_plr[[i_setting]], y_col = "y", 
+                                            d_cols = "d", x_cols = Xnames)
+   
+   double_mlplr_obj = DoubleMLPLR$new(data = data_ml, 
+                                      ml_g = lrn(g_learner), 
+                                      ml_m = lrn(m_learner), 
+                                      dml_procedure = dml_procedure, 
+                                      n_folds = n_folds,
+                                      score = score)
+   set.seed(i_setting)
+   double_mlplr_obj$fit(store_predictions = TRUE)
+   
+   set.seed(i_setting)
+   indx = (names(data_plr[[i_setting]]) %in% c(Xnames, 'y'))
+   data = data_plr[[i_setting]][ , indx]
+   task = mlr3::TaskRegr$new(id = 'ml_g', backend = data, target = 'y')
+   resampling_smpls = rsmp("custom")$instantiate(task,
+                                                 double_mlplr_obj$smpls[[1]]$train_ids,
+                                                 double_mlplr_obj$smpls[[1]]$test_ids)
+   resampling_pred = resample(task, lrn(g_learner), resampling_smpls)
+   preds_g = as.data.table(resampling_pred$prediction())
+   data.table::setorder(preds_g, "row_ids")
+   
+   indx = (names(data_plr[[i_setting]]) %in% c(Xnames, 'd'))
+   data = data_plr[[i_setting]][ , indx]
+   task = mlr3::TaskRegr$new(id = 'ml_m', backend = data, target = 'd')
+   resampling_smpls = rsmp("custom")$instantiate(task,
+                                                 double_mlplr_obj$smpls[[1]]$train_ids,
+                                                 double_mlplr_obj$smpls[[1]]$test_ids)
+   resampling_pred = resample(task, lrn(m_learner), resampling_smpls)
+   preds_m = as.data.table(resampling_pred$prediction())
+   data.table::setorder(preds_m, "row_ids")
+   
+   expect_equal(as.vector(double_mlplr_obj$predictions$ml_g),
+                as.vector(preds_g$response), tolerance = 1e-8)
+   
+   expect_equal(as.vector(double_mlplr_obj$predictions$ml_m),
+                as.vector(preds_m$response), tolerance = 1e-8)
+   
+}
+)
+


### PR DESCRIPTION
- When method `fit()` is called with `store_predictions=TRUE` the first-stage predictions are stored in field `predictions (same dimensions as psi (score function values).
- Draft PR because I want to add some unit tests for the new export feature.