### PR TITLE
fix bug in initialization of learners during tuning

### DIFF
--- a/R/helper.R
+++ b/R/helper.R
@@ -130,7 +130,7 @@ dml_tune = function(learner, X_cols, y_col, data_tune_list,
       select_cols = X_cols,
       learner_class = learner_class)
   })
-  ml_learner = initiate_learner(learner, learner_class, params = list())
+  ml_learner = initiate_learner(learner, learner_class, params = learner$param_set$values)
   tuning_instance = lapply(task_tune, function(x) {
     TuningInstanceSingleCrit$new(
       task = x,


### PR DESCRIPTION
avoid overrriding param_set$values of mlr3 learners during tuning -> https://github.com/DoubleML/doubleml-for-r/issues/83