### PR TITLE
Citation info via command citation("DoubleML")

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -85,8 +85,8 @@ remotes::install_github("DoubleML/doubleml-for-r")
 
 If you use the DoubleML package a citation is highly appreciated:
 
-Bach, P., Chernozhukov, V., Kurz, M. S., and Spindler, M.,
-DoubleML - An Object-Oriented Implementation of Double Machine Learning in R, 2021. 
+Bach, P., Chernozhukov, V., Kurz, M. S., and Spindler, M. (2021),
+DoubleML - An Object-Oriented Implementation of Double Machine Learning in R,
 arXiv:[2103.09603](https://arxiv.org/abs/2103.09603). 
 
 Bibtex-entry:
@@ -100,6 +100,7 @@ Bibtex-entry:
       archivePrefix={arXiv},
       primaryClass={stat.ML},
       note={arXiv:\href{https://arxiv.org/abs/2103.09603}{2103.09603} [stat.ML]}
+}
 ```
 
 ## References

--- a/README.md
+++ b/README.md
@@ -105,9 +105,9 @@ remotes::install_github("DoubleML/doubleml-for-r")
 
 If you use the DoubleML package a citation is highly appreciated:
 
-Bach, P., Chernozhukov, V., Kurz, M. S., and Spindler, M., DoubleML - An
-Object-Oriented Implementation of Double Machine Learning in R, 2021.
-arXiv:[2103.09603](https://arxiv.org/abs/2103.09603).
+Bach, P., Chernozhukov, V., Kurz, M. S., and Spindler, M. (2021),
+DoubleML - An Object-Oriented Implementation of Double Machine Learning
+in R, arXiv:[2103.09603](https://arxiv.org/abs/2103.09603).
 
 Bibtex-entry:
 
@@ -119,6 +119,7 @@ Bibtex-entry:
           archivePrefix={arXiv},
           primaryClass={stat.ML},
           note={arXiv:\href{https://arxiv.org/abs/2103.09603}{2103.09603} [stat.ML]}
+    }
 
 ## References
 

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -1,0 +1,17 @@
+bibentry(
+  bibtype = "misc",
+  key = "DoubleML2021",
+  title = "{DoubleML} -- {A}n Object-Oriented Implementation of Double Machine Learning in {R}",
+  author = c(
+    person(given = "P.", family = "Bach"),
+    person(given = "V.", family = "Chernozhukov"),
+    person(given = "M. S.", family = "Kurz"),
+    person(given = "M.", family = "Spindler")
+  ),
+  year = 2021,
+  eprint = "2103.09603",
+  archivePrefix = "arXiv",
+  primaryClass = "stat.ML",
+  note= "arXiv:\\href{https://arxiv.org/abs/2103.09603}{2103.09603} [stat.ML]",
+  textVersion = "Bach, P., Chernozhukov, V., Kurz, M. S., and Spindler, M. (2021), DoubleML - An Object-Oriented Implementation of Double Machine Learning in R, arXiv:2103.09603."
+)


### PR DESCRIPTION
With this change, the following citation info is shown when calling `citation("DoubleML")`:

![citation_info](https://user-images.githubusercontent.com/7427117/114028165-7583c700-9878-11eb-8294-ecaeb2caf10f.png)
