### PR TITLE
Fixes for upcoming mlr3 version

### DIFF
--- a/tests/testthat/helper-08-dml_plr.R
+++ b/tests/testthat/helper-08-dml_plr.R
@@ -65,7 +65,7 @@ score = "IV-type", se_type = "ls", ...) {
   # # g_hat_list = mlr::getRRPredictionList(r_g)
   # #g_hat_list = lapply(g_hat_list$test, extract_test_pred)
   # g_hat_list = lapply(g_hat_list, function(x) x$response)
-  g_hat_list = lapply(r_g$data$predictions(), function(x) x$response)
+  g_hat_list = lapply(r_g$predictions(), function(x) x$response)
   # nuisance m
   m_indx = names(data) != y
   data_m = data[, m_indx, drop = FALSE]
@@ -88,7 +88,7 @@ score = "IV-type", se_type = "ls", ...) {
   # # m_hat_list = mlr::getRRPredictionList(r_m)
   # m_hat_list = lapply(m_hat_list, function(x) x$response)
   # # m_hat_list =lapply(m_hat_list$test,  extract_test_pred)
-  m_hat_list = lapply(r_m$data$predictions(), function(x) x$response)
+  m_hat_list = lapply(r_m$predictions(), function(x) x$response)
 
 
   # if ((rin$desc$iters != r_g$pred$instance$desc$iters) ||

--- a/tests/testthat/helper-09-dml_plriv.R
+++ b/tests/testthat/helper-09-dml_plriv.R
@@ -75,7 +75,7 @@ dml_plriv = function(data, y, d, z, k = 2, smpls = NULL, mlmethod,
   # #g_hat_list = lapply(g_hat_list$test, extract_test_pred)
   # g_hat_list = lapply(g_hat_list, function(x) x$response)
   # g_hat_list = lapply(r_g$data$prediction, function(x) x$test$response)
-  g_hat_list = lapply(r_g$data$predictions(), function(x) x$response)
+  g_hat_list = lapply(r_g$predictions(), function(x) x$response)
 
   # nuisance m: E[Z|X]
   m_indx = names(data) != y & names(data) != d
@@ -99,7 +99,7 @@ dml_plriv = function(data, y, d, z, k = 2, smpls = NULL, mlmethod,
   # m_hat_list = lapply(m_hat_list, function(x) x$response)
   # # m_hat_list =lapply(m_hat_list$test,  extract_test_pred)
   # m_hat_list = lapply(r_m$data$prediction, function(x) x$test$response)
-  m_hat_list = lapply(r_m$data$predictions(), function(x) x$response)
+  m_hat_list = lapply(r_m$predictions(), function(x) x$response)
 
 
   # nuisance r: E[D|X]
@@ -124,7 +124,7 @@ dml_plriv = function(data, y, d, z, k = 2, smpls = NULL, mlmethod,
   # r_hat_list = lapply(r_hat_list, function(x) x$response)
   # # m_hat_list =lapply(m_hat_list$test,  extract_test_pred)
   # r_hat_list = lapply(r_r$data$prediction, function(x) x$test$response)
-  r_hat_list = lapply(r_r$data$predictions(), function(x) x$response)
+  r_hat_list = lapply(r_r$predictions(), function(x) x$response)
 
 
 

--- a/tests/testthat/helper-10-dml_irm.R
+++ b/tests/testthat/helper-10-dml_irm.R
@@ -77,7 +77,7 @@ bootstrap = "normal", nRep = 500, ...) {
   # m_hat_list = lapply(m_hat_list, function(x) x$response)
   # # m_hat_list =lapply(m_hat_list$test,  extract_test_pred)
   # m_hat_list = lapply(r_m$data$prediction, function(x) x$test$prob[, "1"])
-  m_hat_list = lapply(r_m$data$predictions(), function(x) x$prob[, "1"])
+  m_hat_list = lapply(r_m$predictions(), function(x) x$prob[, "1"])
 
   # nuisance g0: E[Y|D=0, X]
   g_indx = names(data) != d
@@ -102,7 +102,7 @@ bootstrap = "normal", nRep = 500, ...) {
   # #g_hat_list = lapply(g_hat_list$test, extract_test_pred)
   # g0_hat_list = lapply(g0_hat_list, function(x) x$response)
   # g0_hat_list = lapply(r_g0$data$prediction, function(x) x$test$response)
-  g0_hat_list = lapply(r_g0$data$predictions(), function(x) x$response)
+  g0_hat_list = lapply(r_g0$predictions(), function(x) x$response)
 
   # nuisance g1: E[Y|D=1, X]
   task_g1 = mlr3::TaskRegr$new(id = paste0("nuis_g1_", d), backend = data_g, target = y)
@@ -124,7 +124,7 @@ bootstrap = "normal", nRep = 500, ...) {
   #   g1_hat_list = lapply(g1_hat_list, function(x) x$response)
   # # }
   # g1_hat_list = lapply(r_g1$data$prediction, function(x) x$test$response)
-  g1_hat_list = lapply(r_g1$data$predictions(), function(x) x$response)
+  g1_hat_list = lapply(r_g1$predictions(), function(x) x$response)
 
 
   if ((resampling_m$iters != resampling_g0$iters) ||

--- a/tests/testthat/helper-11-dml_irmiv.R
+++ b/tests/testthat/helper-11-dml_irmiv.R
@@ -99,7 +99,7 @@ dml_irmiv = function(data, y, d, z, k = 2, smpls = NULL, mlmethod, params = list
   # # m_hat_list =lapply(m_hat_list$test,  extract_test_pred)
   #
   # p_hat_list = lapply(r_p$data$prediction, function(x) x$test$prob[, "1"])
-  p_hat_list = lapply(r_p$data$predictions(), function(x) x$prob[, "1"])
+  p_hat_list = lapply(r_p$predictions(), function(x) x$prob[, "1"])
 
   # nuisance mu0: E[Y|Z=0, X]
   mu_indx = names(data) != d & names(data) != z
@@ -125,7 +125,7 @@ dml_irmiv = function(data, y, d, z, k = 2, smpls = NULL, mlmethod, params = list
   # g0_hat_list = lapply(g0_hat_list, function(x) x$response)
   #
   # mu0_hat_list = lapply(r_mu0$data$prediction, function(x) x$test$response)
-  mu0_hat_list = lapply(r_mu0$data$predictions(), function(x) x$response)
+  mu0_hat_list = lapply(r_mu0$predictions(), function(x) x$response)
 
   # nuisance g1: E[Y|Z=1, X]
   task_mu1 = mlr3::TaskRegr$new(id = paste0("nuis_mu1_", z), backend = data_mu, target = y)
@@ -139,7 +139,7 @@ dml_irmiv = function(data, y, d, z, k = 2, smpls = NULL, mlmethod, params = list
 
   r_mu1 = mlr3::resample(task_mu1, ml_mu1, resampling_mu1, store_models = TRUE)
   # mu1_hat_list = lapply(r_mu1$data$prediction, function(x) x$test$response)
-  mu1_hat_list = lapply(r_mu1$data$predictions(), function(x) x$response)
+  mu1_hat_list = lapply(r_mu1$predictions(), function(x) x$response)
 
 
   # nuisance m0: E[D|Z=0, X]
@@ -171,7 +171,7 @@ dml_irmiv = function(data, y, d, z, k = 2, smpls = NULL, mlmethod, params = list
     test_ids_m0 = lapply(1:n_iters, function(x) resampling_m0$test_set(x))
     r_m0 = mlr3::resample(task_m0, ml_m0, resampling_m0, store_models = TRUE)
     # m0_hat_list = lapply(r_m0$data$prediction, function(x) x$test$prob[, "1"])
-    m0_hat_list = lapply(r_m0$data$predictions(), function(x) x$prob[, "1"])
+    m0_hat_list = lapply(r_m0$predictions(), function(x) x$prob[, "1"])
   }
 
   if (never_takers == FALSE) {
@@ -194,7 +194,7 @@ dml_irmiv = function(data, y, d, z, k = 2, smpls = NULL, mlmethod, params = list
     test_ids_m1 = lapply(1:n_iters, function(x) resampling_m1$test_set(x))
     r_m1 = mlr3::resample(task_m1, ml_m1, resampling_m1, store_models = TRUE)
     # m1_hat_list = lapply(r_m1$data$prediction, function(x) x$test$prob[, "1"])
-    m1_hat_list = lapply(r_m1$data$predictions(), function(x) x$prob[, "1"])
+    m1_hat_list = lapply(r_m1$predictions(), function(x) x$prob[, "1"])
   }
 
   if ((resampling_p$iters != resampling_mu0$iters) ||


### PR DESCRIPTION
I'm sorry that we have to make some API changes again. We received multiple reports from users which were using the (internal) data structure in field `$data` of `ResampleResult` and `BenchmarkResult` instead of using the designated getters provided by both container objects. This lead to confusion and in one case to wrong results of a data analysis. Therefore, we decided to make the `$data` field private.

AFAICT, some unit tests are also affected by this change. I've tried to fix them in this PR. 

