### PR TITLE
Run unit tests with `mlr3` in dev version on github actions

### DIFF
--- a/.github/workflows/rcheck.yml
+++ b/.github/workflows/rcheck.yml
@@ -56,8 +56,8 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ${{ env.R_LIBS_USER }}
-          key: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}
-          restore-keys: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-
+          key: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-${{ matrix.config.mlr3 }}-1-${{ hashFiles('.github/depends.Rds') }}
+          restore-keys: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-${{ matrix.config.mlr3 }}-1-
 
       - name: Install system dependencies
         if: runner.os == 'Linux'
@@ -98,7 +98,7 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@main
         with:
-          name: ${{ runner.os }}-r${{ matrix.config.r }}-results
+          name: ${{ runner.os }}-r${{ matrix.config.r }}-${{ matrix.config.mlr3 }}-results
           path: check
 
       - name: Install covr

--- a/.github/workflows/rcheck.yml
+++ b/.github/workflows/rcheck.yml
@@ -16,7 +16,7 @@ jobs:
   R-CMD-check:
     runs-on: ${{ matrix.config.os }}
 
-    name: ${{ matrix.config.os }} (${{ matrix.config.r }})
+    name: ${{ matrix.config.os }} (R ${{ matrix.config.r }}; mlr3 ${{ matrix.config.mlr3 }})
 
     strategy:
       fail-fast: false

--- a/.github/workflows/rcheck.yml
+++ b/.github/workflows/rcheck.yml
@@ -22,10 +22,11 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - {os: windows-latest, r: 'release'}
-          - {os: macOS-latest, r: 'release'}
-          - {os: ubuntu-20.04, r: 'release', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
-          - {os: ubuntu-20.04, r: 'devel', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
+          - {os: windows-latest, r: 'release', mlr3: 'release'}
+          - {os: macOS-latest, r: 'release', mlr3: 'release'}
+          - {os: ubuntu-20.04, r: 'release', mlr3: 'release', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
+          - {os: ubuntu-20.04, r: 'devel', mlr3: 'release', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
+          - {os: ubuntu-20.04, r: 'devel', mlr3: 'dev', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
 
     env:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
@@ -70,6 +71,12 @@ jobs:
         run: |
           remotes::install_deps(dependencies = TRUE)
           remotes::install_cran("rcmdcheck")
+        shell: Rscript {0}
+
+      - name: mlr3 dev version
+        if: runner.mlr3 == 'dev'
+        run: |
+          remotes::install_github("mlr-org/mlr3")
         shell: Rscript {0}
 
       - name: Check

--- a/.github/workflows/rcheck.yml
+++ b/.github/workflows/rcheck.yml
@@ -74,7 +74,7 @@ jobs:
         shell: Rscript {0}
 
       - name: mlr3 dev version
-        if: runner.mlr3 == 'dev'
+        if: matrix.config.mlr3 == 'dev'
         run: |
           remotes::install_github("mlr-org/mlr3")
         shell: Rscript {0}


### PR DESCRIPTION
- `mlr3` is the most important dependency of `DoubleML`.
- To make it easier to keep up-to-date with regards to API changes, it makes sense to not only run unit tests with the most recent release of `mlr3` but also with the current dev version form GitHub: https://github.com/mlr-org/mlr3. Therefore, I added a fifth job to our unit test workflow on GitHub, see screenshot:
![image](https://user-images.githubusercontent.com/7427117/118805749-92afaa80-b8a6-11eb-87c7-78e9c1a7c2c2.png)
- This should help us in two ways:
   - Due to scheduled unit test runs (three per week) it keeps us up-to-date with regards to API changes / incompatibilities.
   - When we have to adapt things in `DoubleML` due to API changes in `mlr3`, we automatically get checks which assure compatibility with both the released and the dev version of `mlr3`.

@mllg: FYI