### PR TITLE
prevent using the subclassed methods check_score and check_data when constructing DoubleML objects

### DIFF
--- a/R/double_ml.R
+++ b/R/double_ml.R
@@ -829,7 +829,6 @@ DoubleML = R6Class("DoubleML",
       # check and pick up obj_dml_data
 
       assert_class(data, "DoubleMLData")
-      private$check_data(data)
       self$data = data
 
       # initialize learners and parameters which are set model specific
@@ -853,7 +852,7 @@ DoubleML = R6Class("DoubleML",
       # check and set dml_procedure and score
       assert_choice(dml_procedure, c("dml1", "dml2"))
       self$dml_procedure = dml_procedure
-      self$score = private$check_score(score)
+      self$score = score
 
       if (self$n_folds == 1 & self$apply_cross_fitting) {
         message(paste(

--- a/R/double_ml_iivm.R
+++ b/R/double_ml_iivm.R
@@ -218,6 +218,9 @@ DoubleMLIIVM = R6Class("DoubleMLIIVM",
         dml_procedure,
         draw_sample_splitting,
         apply_cross_fitting)
+      
+      private$check_data(self$data)
+      private$check_score(self$score)
       private$learner_class = list(
         "ml_g" = NULL,
         "ml_m" = NULL,
@@ -456,7 +459,7 @@ DoubleMLIIVM = R6Class("DoubleMLIIVM",
         valid_score = c("LATE")
         assertChoice(score, valid_score)
       }
-      return(score)
+      return()
     },
     check_data = function(obj_dml_data) {
       one_treat = (obj_dml_data$n_treat == 1)

--- a/R/double_ml_irm.R
+++ b/R/double_ml_irm.R
@@ -169,6 +169,8 @@ DoubleMLIRM = R6Class("DoubleMLIRM",
         draw_sample_splitting,
         apply_cross_fitting)
 
+      private$check_data(self$data)
+      private$check_score(self$score)
       private$learner_class = list(
         "ml_g" = NULL,
         "ml_m" = NULL)
@@ -353,7 +355,7 @@ DoubleMLIRM = R6Class("DoubleMLIRM",
           assertChoice(score, valid_score)
         }
       }
-      return(score)
+      return()
     },
     check_data = function(obj_dml_data) {
       if (!is.null(obj_dml_data$z_cols)) {

--- a/R/double_ml_pliv.R
+++ b/R/double_ml_pliv.R
@@ -174,6 +174,9 @@ DoubleMLPLIV = R6Class("DoubleMLPLIV",
         dml_procedure,
         draw_sample_splitting,
         apply_cross_fitting)
+      
+      private$check_data(self$data)
+      private$check_score(self$score)
       assert_logical(partialX, len = 1)
       assert_logical(partialZ, len = 1)
       self$partialX = partialX
@@ -668,7 +671,7 @@ DoubleMLPLIV = R6Class("DoubleMLPLIV",
         valid_score = c("partialling out")
         assertChoice(score, valid_score)
       }
-      return(score)
+      return()
     },
     check_data = function(obj_dml_data) {
       return()

--- a/R/double_ml_plr.R
+++ b/R/double_ml_plr.R
@@ -145,6 +145,8 @@ DoubleMLPLR = R6Class("DoubleMLPLR",
         draw_sample_splitting,
         apply_cross_fitting)
 
+      private$check_data(self$data)
+      private$check_score(self$score)
       private$learner_class = list(
         "ml_g" = NULL,
         "ml_m" = NULL)
@@ -261,7 +263,7 @@ DoubleMLPLR = R6Class("DoubleMLPLR",
         valid_score = c("IV-type", "partialling out")
         assertChoice(score, valid_score)
       }
-      return(score)
+      return()
     },
     check_data = function(obj_dml_data) {
       if (!is.null(obj_dml_data$z_cols)) {


### PR DESCRIPTION
prevent using the subclassed methods check_score and check_data when constructing DoubleML objects (see also https://github.com/DoubleML/doubleml-for-py/pull/103)