### PR TITLE
Initialization of numeric matrices, vectors and arrays; replace `print()` by `cat()`

### DIFF
--- a/R/double_ml.R
+++ b/R/double_ml.R
@@ -755,9 +755,8 @@ DoubleML = R6Class("DoubleML",
         a = c(a, 1 - a)
         pct = format.perc(a, 3)
         fac = qnorm(a)
-        ci = array(NA_real_, dim = c(length(parm), 2L), dimnames = list(
-          parm,
-          pct))
+        ci = array(NA_real_, dim = c(length(parm), 2L),
+                   dimnames = list(parm, pct))
         ci[] = self$coef[parm] + self$se[parm] %o% fac
       }
 
@@ -766,7 +765,8 @@ DoubleML = R6Class("DoubleML",
         a = (1 - level)
         ab = c(a / 2, 1 - a / 2)
         pct = format.perc(ab, 3)
-        ci = array(NA, dim = c(length(parm), 2L), dimnames = list(parm, pct))
+        ci = array(NA_real_, dim = c(length(parm), 2L),
+                   dimnames = list(parm, pct))
 
         if (all(is.na(self$boot_coef))) {
           stop(paste(
@@ -970,8 +970,8 @@ DoubleML = R6Class("DoubleML",
     t_stat_ = NULL,
     tuning_res_ = NULL,
     n_rep_boot = NULL,
-    i_rep = NA,
-    i_treat = NA,
+    i_rep = NA_integer_,
+    i_treat = NA_integer_,
     fold_specific_params = NULL,
     summary_table = NULL,
     learner_class = list(),
@@ -1168,29 +1168,31 @@ DoubleML = R6Class("DoubleML",
     },
     initialize_arrays = function() {
 
-      private$psi_ = array(NA, dim = c(
+      private$psi_ = array(NA_real_, dim = c(
         self$data$n_obs, self$n_rep,
         self$data$n_treat))
-      private$psi_a_ = array(NA, dim = c(
+      private$psi_a_ = array(NA_real_, dim = c(
         self$data$n_obs, self$n_rep,
         self$data$n_treat))
-      private$psi_b_ = array(NA, dim = c(
+      private$psi_b_ = array(NA_real_, dim = c(
         self$data$n_obs, self$n_rep,
         self$data$n_treat))
 
-      private$coef_ = array(NA, dim = c(self$data$n_treat))
-      private$se_ = array(NA, dim = c(self$data$n_treat))
+      private$coef_ = array(NA_real_, dim = c(self$data$n_treat))
+      private$se_ = array(NA_real_, dim = c(self$data$n_treat))
 
-      private$all_coef_ = array(NA, dim = c(self$data$n_treat, self$n_rep))
-      private$all_se_ = array(NA, dim = c(self$data$n_treat, self$n_rep))
+      private$all_coef_ = array(NA_real_,
+                                dim = c(self$data$n_treat, self$n_rep))
+      private$all_se_ = array(NA_real_,
+                              dim = c(self$data$n_treat, self$n_rep))
 
       if (self$dml_procedure == "dml1") {
         if (self$apply_cross_fitting) {
-          private$all_dml1_coef_ = array(NA, dim = c(
+          private$all_dml1_coef_ = array(NA_real_, dim = c(
             self$data$n_treat, self$n_rep,
             self$n_folds))
         } else {
-          private$all_dml1_coef_ = array(NA, dim = c(
+          private$all_dml1_coef_ = array(NA_real_, dim = c(
             self$data$n_treat, self$n_rep,
             1))
         }
@@ -1198,17 +1200,17 @@ DoubleML = R6Class("DoubleML",
     },
     initialize_boot_arrays = function(n_rep_boot) {
       private$n_rep_boot = n_rep_boot
-      private$boot_coef_ = array(NA, dim = c(
+      private$boot_coef_ = array(NA_real_, dim = c(
         self$data$n_treat,
         n_rep_boot * self$n_rep))
-      private$boot_t_stat_ = array(NA, dim = c(
+      private$boot_t_stat_ = array(NA_real_, dim = c(
         self$data$n_treat,
         n_rep_boot * self$n_rep))
     },
     initialize_predictions = function() {
       private$predictions_ = sapply(self$params_names(),
         function(key) {
-          array(NA, dim = c(
+          array(NA_real_, dim = c(
             self$data$n_obs, self$n_rep,
             self$data$n_treat))
         },
@@ -1243,7 +1245,7 @@ DoubleML = R6Class("DoubleML",
       if (dml_procedure == "dml1") {
         # Note that length(test_ids) is only not equal to self.n_folds
         # if self$apply_cross_fitting ==False
-        thetas = rep(NA, length(test_ids))
+        thetas = rep(NA_real_, length(test_ids))
         for (i_fold in seq_len(length(test_ids))) {
           test_index = test_ids[[i_fold]]
           thetas[i_fold] = private$orth_est(inds = test_index)

--- a/R/double_ml.R
+++ b/R/double_ml.R
@@ -690,7 +690,7 @@ DoubleML = R6Class("DoubleML",
         message("fit() not yet called.")
       } else {
         k = length(self$coef)
-        table = matrix(NA, ncol = 4, nrow = k)
+        table = matrix(NA_real_, ncol = 4, nrow = k)
         rownames(table) = names(self$coef)
         colnames(table) = c("Estimate.", "Std. Error", "t value", "Pr(>|t|)")
         table[, 1] = self$coef

--- a/R/double_ml.R
+++ b/R/double_ml.R
@@ -700,9 +700,8 @@ DoubleML = R6Class("DoubleML",
         private$summary_table = table
 
         if (length(k)) {
-          print(paste(
-            "Estimates and significance testing of the",
-            "effect of target variables"))
+          cat("Estimates and significance testing of the",
+              "effect of target variables\n")
           res = as.matrix(printCoefmat(private$summary_table,
             digits = digits,
             P.values = TRUE,

--- a/R/helper.R
+++ b/R/helper.R
@@ -173,7 +173,7 @@ extract_prediction = function(obj_resampling, learner_class, n_obs,
         1:n_iters,
         function(x) as.data.table(obj_resampling$predictions("train")[[x]]))
       for (i_iter in 1:n_iters) {
-        preds_vec = as.numeric(rep(NA, n_obs))
+        preds_vec = rep(NA_real_, n_obs)
         f_hat = f_hat_list[[i_iter]]
         preds_vec[f_hat[[ind_name]]] = f_hat[[resp_name]]
         preds[[i_iter]] = preds_vec
@@ -189,7 +189,7 @@ extract_prediction = function(obj_resampling, learner_class, n_obs,
       }
     }
   } else {
-    preds = as.numeric(rep(NA, n_obs))
+    preds = rep(NA_real_, n_obs)
     if (testR6(obj_resampling, classes = "ResampleResult")) obj_resampling = list(obj_resampling)
     n_obj_rsmp = length(obj_resampling)
     for (i_obj_rsmp in 1:n_obj_rsmp) {

--- a/tests/testthat/helper-01-helper_functions.R
+++ b/tests/testthat/helper-01-helper_functions.R
@@ -40,8 +40,8 @@ functional_bootstrap = function(theta, se, psi, psi_a, k, smpls,
                                 n_rep_boot, weights) {
   score = psi
   J = mean(psi_a)
-  boot_coef = matrix(NA, nrow = 1, ncol = n_rep_boot)
-  boot_t_stat = matrix(NA, nrow = 1, ncol = n_rep_boot)
+  boot_coef = matrix(NA_real_, nrow = 1, ncol = n_rep_boot)
+  boot_t_stat = matrix(NA_real_, nrow = 1, ncol = n_rep_boot)
   for (i in seq(n_rep_boot)) {
     boot_coef[1, i] = mean(weights[i, ] * 1 / J * score)
     boot_t_stat[1, i] = boot_coef[1, i] / se

--- a/tests/testthat/helper-08-dml_plr.R
+++ b/tests/testthat/helper-08-dml_plr.R
@@ -335,7 +335,7 @@ boot_plr_multitreat = function(thetas, ses, data, y, d,
   for (i_rep in 1:n_rep) {
     n = nrow(data)
     weights = draw_bootstrap_weights(bootstrap, n_rep_boot, n)
-    boot_theta = boot_t_stat = matrix(NA, nrow = n_d, ncol = n_rep_boot)
+    boot_theta = boot_t_stat = matrix(NA_real_, nrow = n_d, ncol = n_rep_boot)
     for (i_d in seq(n_d)) {
       this_res = boot_plr_single_split(thetas[[i_rep]][i_d], ses[[i_rep]][i_d],
                                        data, y, d[i_d], n_folds, smpls[[i_rep]],

--- a/tests/testthat/helper-08-dml_plr.R
+++ b/tests/testthat/helper-08-dml_plr.R
@@ -9,7 +9,7 @@ dml_plr = function(data, y, d,
     smpls = lapply(1:n_rep, function(x) sample_splitting(n_folds, data))
   }
 
-  all_thetas = all_ses = rep(NA, n_rep)
+  all_thetas = all_ses = rep(NA_real_, n_rep)
   all_preds = list()
 
   for (i_rep in 1:n_rep) {
@@ -66,7 +66,7 @@ dml_plr_multitreat = function(data, y, d,
   
   for (i_rep in 1:n_rep) {
     this_smpl = smpls[[i_rep]]
-    thetas_this_rep = ses_this_rep = rep(NA, n_d)
+    thetas_this_rep = ses_this_rep = rep(NA_real_, n_d)
     all_preds_this_rep = list()
     
     for (i_d in seq(n_d)) {
@@ -97,7 +97,7 @@ dml_plr_multitreat = function(data, y, d,
     
   }
   
-  theta = se = t = pval = rep(NA, n_d)
+  theta = se = t = pval = rep(NA_real_, n_d)
   if (length(this_smpl$train_ids) > 1) {
     n = nrow(data)
   } else {
@@ -145,7 +145,7 @@ fit_plr_single_split = function(data, y, d,
   
   # DML 1
   if (dml_procedure == "dml1") {
-    thetas = rep(NA, n_folds)
+    thetas = rep(NA_real_, n_folds)
     for (i in 1:n_folds) {
       test_index = test_ids[[i]]
       
@@ -249,7 +249,7 @@ compute_plr_residuals = function(data, y, d, n_folds, smpls, all_preds) {
   D = data[, d]
   Y = data[, y]
   
-  v_hat = u_hat = w_hat = rep(NA, n)
+  v_hat = u_hat = w_hat = rep(NA_real_, n)
   
   for (i in 1:n_folds) {
     test_index = test_ids[[i]]
@@ -268,7 +268,7 @@ compute_plr_residuals = function(data, y, d, n_folds, smpls, all_preds) {
 
 # Orthogonalized Estimation of Coefficient in PLR
 orth_plr_dml = function(u_hat, v_hat, v_hatd, score) {
-  theta = NA
+  theta = NA_real_
 
   if (score == "partialling out") {
     res_fit = stats::lm(u_hat ~ 0 + v_hat)

--- a/tests/testthat/helper-09-dml_pliv.R
+++ b/tests/testthat/helper-09-dml_pliv.R
@@ -9,7 +9,7 @@ dml_pliv = function(data, y, d, z,
     smpls = lapply(1:n_rep, function(x) sample_splitting(n_folds, data))
   }
   
-  all_thetas = all_ses = rep(NA, n_rep)
+  all_thetas = all_ses = rep(NA_real_, n_rep)
   all_preds = list()
   
   for (i_rep in 1:n_rep) {
@@ -30,7 +30,7 @@ dml_pliv = function(data, y, d, z,
     
     # DML 1
     if (dml_procedure == "dml1") {
-      thetas = vars = rep(NA, n_folds)
+      thetas = vars = rep(NA_real_, n_folds)
       for (i in 1:n_folds) {
         test_index = test_ids[[i]]
         orth_est = orth_pliv_dml(
@@ -149,7 +149,7 @@ compute_pliv_residuals = function(data, y, d, z, n_folds, smpls, all_preds) {
   Y = data[, y]
   Z = data[, z]
   
-  v_hat = u_hat = w_hat = rep(NA, n)
+  v_hat = u_hat = w_hat = rep(NA_real_, n)
   
   for (i in 1:n_folds) {
     test_index = test_ids[[i]]

--- a/tests/testthat/helper-10-dml_irm.R
+++ b/tests/testthat/helper-10-dml_irm.R
@@ -10,7 +10,7 @@ dml_irm = function(data, y, d,
     smpls = lapply(1:n_rep, function(x) sample_splitting(n_folds, data))
   }
   
-  all_thetas = all_ses = rep(NA, n_rep)
+  all_thetas = all_ses = rep(NA_real_, n_rep)
   all_preds = list()
   
   for (i_rep in 1:n_rep) {
@@ -36,7 +36,7 @@ dml_irm = function(data, y, d,
     
     # DML 1
     if (dml_procedure == "dml1") {
-      thetas = vars = rep(NA, n_folds)
+      thetas = vars = rep(NA_real_, n_folds)
       
       for (i in 1:n_folds) {
         test_index = test_ids[[i]]
@@ -184,7 +184,7 @@ extract_irm_residuals = function(data, y, d, n_folds, smpls, all_preds, score,
   D = data[, d]
   Y = data[, y]
   
-  g0_hat = g1_hat = u0_hat = u1_hat = m_hat = p_hat = rep(NA, n)
+  g0_hat = g1_hat = u0_hat = u1_hat = m_hat = p_hat = rep(NA_real_, n)
   
   for (i in 1:n_folds) {
     test_index = test_ids[[i]]

--- a/tests/testthat/helper-11-dml_iivm.R
+++ b/tests/testthat/helper-11-dml_iivm.R
@@ -12,7 +12,7 @@ dml_irmiv = function(data, y, d, z,
     smpls = lapply(1:n_rep, function(x) sample_splitting(n_folds, data))
   }
   
-  all_thetas = all_ses = rep(NA, n_rep)
+  all_thetas = all_ses = rep(NA_real_, n_rep)
   all_preds = list()
   
   for (i_rep in 1:n_rep) {
@@ -39,7 +39,7 @@ dml_irmiv = function(data, y, d, z,
     
     # DML 1
     if (dml_procedure == "dml1") {
-      thetas = vars = rep(NA, n_folds)
+      thetas = vars = rep(NA_real_, n_folds)
       for (i in 1:n_folds) {
         test_index = test_ids[[i]]
         orth_est = orth_irmiv_dml(
@@ -257,7 +257,7 @@ extract_iivm_preds = function(data, y, d, z, n_folds, smpls, all_preds,
   D = data[, d]
   Y = data[, y]
   Z = data[, z]
-  m_hat = g0_hat = g1_hat = r0_hat = r1_hat = rep(NA, n)
+  m_hat = g0_hat = g1_hat = r0_hat = r1_hat = rep(NA_real_, n)
   
   for (i in 1:n_folds) {
     test_index = test_ids[[i]]
@@ -279,7 +279,7 @@ extract_iivm_preds = function(data, y, d, z, n_folds, smpls, all_preds,
 
 # Orthogonalized Estimation of Coefficient in irm
 orth_irmiv_dml = function(m_hat, g0_hat, g1_hat, r0_hat, r1_hat, d, y, z, score) {
-  theta = NA
+  theta = NA_real_
 
   if (score == "LATE" | score == "partialling out") {
     theta = 1 / mean(r1_hat - r0_hat + z * (d - r1_hat) / m_hat - ((1 - z) * (d - r0_hat) / (1 - m_hat))) *

--- a/tests/testthat/helper-12-p_adjust.R
+++ b/tests/testthat/helper-12-p_adjust.R
@@ -67,7 +67,7 @@ p_adjust.DML = function(x, method = "RW", ...) {
     # v = x$residuals$v
     # ev = e * v
     # Ev2 = colMeans(v^2)
-    # Omegahat = matrix(NA, ncol = k, nrow = k)
+    # Omegahat = matrix(NA_real_, ncol = k, nrow = k)
     # for (j in 1:k) {
     #   for (l in 1:k) {
     #     Omegahat[j, l] = Omegahat[l, j] = 1/(Ev2[j] * Ev2[l]) * mean(ev[, j] * ev[, l])
@@ -75,7 +75,7 @@ p_adjust.DML = function(x, method = "RW", ...) {
     # }
     # se = sqrt(diag(Omegahat))
     #
-    # Beta_i = matrix(NA, ncol = k, nrow = B)
+    # Beta_i = matrix(NA_real_, ncol = k, nrow = B)
     # for (i in 1:B) {
     #   Beta_i[i, ] = MASS::mvrnorm(mu = rep(0, k), Sigma = Omegahat/n)
     # }

--- a/tests/testthat/helper-13-dml_pliv_partial_x.R
+++ b/tests/testthat/helper-13-dml_pliv_partial_x.R
@@ -9,7 +9,7 @@ dml_pliv_partial_x = function(data, y, d, z,
     smpls = lapply(1:n_rep, function(x) sample_splitting(n_folds, data))
   }
   
-  all_thetas = all_ses = rep(NA, n_rep)
+  all_thetas = all_ses = rep(NA_real_, n_rep)
   all_preds = list()
   
   for (i_rep in 1:n_rep) {
@@ -29,7 +29,7 @@ dml_pliv_partial_x = function(data, y, d, z,
     
     # DML 1
     if (dml_procedure == "dml1") {
-      thetas = vars = rep(NA, n_folds)
+      thetas = vars = rep(NA_real_, n_folds)
       for (i in 1:n_folds) {
         test_index = this_smpl$test_ids[[i]]
         orth_est = orth_pliv_partial_x_dml(
@@ -129,7 +129,7 @@ fit_nuisance_pliv_partial_x = function(data, y, d, z,
   r_hat_list = lapply(r_r$predictions(), function(x) x$response)
   
   n = nrow(data)
-  r_hat_array = rep(NA, n)
+  r_hat_array = rep(NA_real_, n)
   m_hat_array = matrix(NA_real_, nrow = n, ncol = n_z)
   
   for (i_fold in seq_len(length(test_ids))) {
@@ -164,7 +164,7 @@ compute_pliv_partial_x_residuals = function(data, y, d, z, n_folds, smpls,
   D = data[, d]
   Y = data[, y]
   
-  u_hat = w_hat = rep(NA, n)
+  u_hat = w_hat = rep(NA_real_, n)
   
   for (i in 1:n_folds) {
     test_index = test_ids[[i]]

--- a/tests/testthat/helper-13-dml_pliv_partial_x.R
+++ b/tests/testthat/helper-13-dml_pliv_partial_x.R
@@ -130,7 +130,7 @@ fit_nuisance_pliv_partial_x = function(data, y, d, z,
   
   n = nrow(data)
   r_hat_array = rep(NA, n)
-  m_hat_array = matrix(NA, nrow = n, ncol = n_z)
+  m_hat_array = matrix(NA_real_, nrow = n, ncol = n_z)
   
   for (i_fold in seq_len(length(test_ids))) {
     test_index = test_ids[[i_fold]]

--- a/tests/testthat/helper-14-dml_pliv_partial_z.R
+++ b/tests/testthat/helper-14-dml_pliv_partial_z.R
@@ -8,7 +8,7 @@ dml_pliv_partial_z = function(data, y, d, z,
     smpls = lapply(1:n_rep, function(x) sample_splitting(n_folds, data))
   }
   
-  all_thetas = all_ses = rep(NA, n_rep)
+  all_thetas = all_ses = rep(NA_real_, n_rep)
   all_preds = list()
   
   for (i_rep in 1:n_rep) {
@@ -28,7 +28,7 @@ dml_pliv_partial_z = function(data, y, d, z,
     
     # DML 1
     if (dml_procedure == "dml1") {
-      thetas = vars = rep(NA, n_folds)
+      thetas = vars = rep(NA_real_, n_folds)
       for (i in 1:n_folds) {
         test_index = this_smpl$test_ids[[i]]
         orth_est = orth_pliv_partial_z_dml(
@@ -110,7 +110,7 @@ compute_pliv_partial_z_residuals = function(data, y, d, z, n_folds, smpls,
 
   r_hat_list = all_preds$r_hat_list
   n = nrow(data)
-  r_hat = rep(NA, n)
+  r_hat = rep(NA_real_, n)
   
   for (i in 1:n_folds) {
     test_index = test_ids[[i]]

--- a/tests/testthat/helper-15-dml_pliv_partial_xz.R
+++ b/tests/testthat/helper-15-dml_pliv_partial_xz.R
@@ -8,7 +8,7 @@ dml_pliv_partial_xz = function(data, y, d, z,
     smpls = lapply(1:n_rep, function(x) sample_splitting(n_folds, data))
   }
   
-  all_thetas = all_ses = rep(NA, n_rep)
+  all_thetas = all_ses = rep(NA_real_, n_rep)
   all_preds = list()
   
   for (i_rep in 1:n_rep) {
@@ -28,7 +28,7 @@ dml_pliv_partial_xz = function(data, y, d, z,
     
     # DML 1
     if (dml_procedure == "dml1") {
-      thetas = vars = rep(NA, n_folds)
+      thetas = vars = rep(NA_real_, n_folds)
       for (i in 1:n_folds) {
         test_index = this_smpl$test_ids[[i]]
         orth_est = orth_pliv_partial_xz_dml(
@@ -119,7 +119,7 @@ fit_nuisance_pliv_partial_xz = function(data, y, d, z,
   # nuisance r
   r_hat_list = list()
   for (i in seq_len(length(train_ids))) {
-    m_hat_train = rep(NA, n)
+    m_hat_train = rep(NA_real_, n)
     train_index = train_ids[[i]]
     m_hat_train[train_index] = m_hat_list_train[[i]]
     r_indx = names(data) != y & names(data) != d & (names(data) %in% z == FALSE)
@@ -156,7 +156,7 @@ compute_pliv_partial_xz_residuals = function(data, y, d, z, n_folds, smpls,
   D = data[, d]
   Y = data[, y]
   
-  u_hat = v_hat = w_hat = rep(NA, n)
+  u_hat = v_hat = w_hat = rep(NA_real_, n)
   
   for (i in 1:n_folds) {
     test_index = test_ids[[i]]


### PR DESCRIPTION
- Initialize all numeric matrices, vectors and arrays with the correct data type by using `NA_real_` instead of `NA`
- Replace a `print()` call with `cat()`