### PR TITLE
Contributing guidelines

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -4,6 +4,7 @@
 ^docs$
 ^pkgdown$
 ^README.Rmd
+^CONTRIBUTING.md
 ^\.github$
 ^codecov\.yml$
 ^doc$

--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -5,6 +5,7 @@
 ^pkgdown$
 ^README.Rmd
 ^CONTRIBUTING.md
+^CODE_OF_CONDUCT.md
 ^\.github$
 ^codecov\.yml$
 ^doc$

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -19,6 +19,6 @@ Please fill out this PR checklist (see our [contributing guidelines](https://git
 - [ ] The title of the pull request summarizes the changes made.
 - [ ] The PR contains a detailed description of all changes and additions.
 - [ ] References to related issues or PRs are added.
-- [ ] The code passes all (unit) tests.
+- [ ] The code passes `R CMD check` and all (unit) tests.
 - [ ] Enhancements or new feature are equipped with unit tests.
 - [ ] The changes adhere to the ["mlr-style" standards](https://github.com/DoubleML/doubleml-for-r/blob/master/CONTRIBUTING.md#checklist-for-pull-requests-pr) for details).

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -19,6 +19,6 @@ Please fill out this PR checklist (see our [contributing guidelines](https://git
 - [ ] The title of the pull request summarizes the changes made.
 - [ ] The PR contains a detailed description of all changes and additions.
 - [ ] References to related issues or PRs are added.
-- [ ] The code passes `R CMD check` and all (unit) tests.
+- [ ] The code passes `R CMD check` and all (unit) tests (see our [contributing guidelines](https://github.com/DoubleML/doubleml-for-r/blob/master/CONTRIBUTING.md#checklist-for-pull-requests-pr) for details).
 - [ ] Enhancements or new feature are equipped with unit tests.
-- [ ] The changes adhere to the ["mlr-style" standards](https://github.com/DoubleML/doubleml-for-r/blob/master/CONTRIBUTING.md#checklist-for-pull-requests-pr) for details).
+- [ ] The changes adhere to the "mlr-style" standards (see our [contributing guidelines](https://github.com/DoubleML/doubleml-for-r/blob/master/CONTRIBUTING.md#checklist-for-pull-requests-pr) for details).

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,24 @@
+Thanks for contributing to DoubleML.
+Before submitting a PR, please take a look at our [contribution guidelines](https://github.com/DoubleML/doubleml-for-r/blob/master/CONTRIBUTING.md).
+Additionally, please fill out the PR checklist below.
+
+### Description
+Please describe all changes and additions.
+In addition, you may want to comment on the diff in GitHub.
+
+### Reference to Issues or PRs
+Add references to related issues or PRs here.
+
+### Comments
+Here you can add further comments.
+You can also delete this section, if it is not necessary.
+
+### PR Checklist
+Please fill out this PR checklist (see our [contributing guidelines](https://github.com/DoubleML/doubleml-for-r/blob/master/CONTRIBUTING.md#checklist-for-pull-requests-pr) for details).
+
+- [ ] The title of the pull request summarizes the changes made.
+- [ ] The PR contains a detailed description of all changes and additions.
+- [ ] References to related issues or PRs are added.
+- [ ] The code passes all (unit) tests.
+- [ ] Enhancements or new feature are equipped with unit tests.
+- [ ] The changes adhere to the ["mlr-style" standards](https://github.com/DoubleML/doubleml-for-r/blob/master/CONTRIBUTING.md#checklist-for-pull-requests-pr) for details).

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,133 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity
+and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+
+* Being respectful of differing opinions, viewpoints, and experiences
+
+* Giving and gracefully accepting constructive feedback
+
+* Accepting responsibility and apologizing to those affected by our mistakes,
+and learning from the experience
+
+* Focusing on what is best not just for us as individuals, but for the
+overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or
+advances of any kind
+
+* Trolling, insulting or derogatory comments, and personal or political attacks
+
+* Public or private harassment
+
+* Publishing others' private information, such as a physical or email
+address, without their explicit permission
+
+* Other conduct which could reasonably be considered inappropriate in a
+professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the project maintainers.
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series
+of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or
+permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within
+the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the Contributor Covenant [homepage](https://www.contributor-covenant.org),
+version 2.0, available at
+https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct
+enforcement ladder](https://github.com/mozilla/diversity).
+
+For answers to common questions about this code of conduct, see the FAQ at
+https://www.contributor-covenant.org/faq. Translations are available at
+https://www.contributor-covenant.org/translations.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,7 +79,7 @@ $ git merge upstream/master
 ```
 
 5. **Develop** your code changes. A helpful resource for package development in R
-is Hadley Wickham's [R Packages](https://r-pkgs.org/preface.html).
+is Hadley Wickham's [R Packages](https://r-pkgs.org/preface.html) and [rOpenSci Packages](https://devguide.ropensci.org/).
 The changes can be added and pushed via
 ```bash
 $ git add your_new_file your_modified_file
@@ -99,12 +99,12 @@ When opening the PR you will be guided with a checklist.
 
 - [x] **References** to related issues or PRs are added.
 
-- [x] The code passes `R CMD check` and **all (unit) tests**
+- [x] The code passes `R CMD check` and **all (unit) tests**.
 To check your code for common problems, run
 ```R
 devtools::check()
 ```
-In case you only want to run the tests, run
+By default, this runs all tests. In case you only want to run the tests, run
 ```R
 devtools::test()
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,176 @@
+# DoubleML - Contributing Guidelines <a href="https://docs.doubleml.org"><img src="man/figures/logo.png" align="right" width = "120" /></a>
+
+DoubleML is a community effort.
+Everyone is welcome to contribute.
+All contributors should adhere to this contributing guidelines
+and our [code of conduct](https://github.com/DoubleML/doubleml-for-r/blob/master/CODE_OF_CONDUCT.md).
+The contributing guidelines are particularly helpful to get started for your first contribution.
+
+## Submit a Bug Report :bug:
+To submit a **bug report**, you can use our
+[issue template for bug reports](https://github.com/DoubleML/doubleml-for-r/issues/new/choose).
+
+- A good bug report contains a **minimum reproducible code snippet**, like for example
+
+```R
+library(DoubleML)
+library(mlr3)
+library(mlr3learners)
+library(data.table)
+set.seed(2)
+ml_g = lrn("regr.ranger", num.trees = 10, max.depth = 2)
+ml_m = ml_g$clone()
+obj_dml_data = make_plr_CCDDHNR2018(alpha = 0.5)
+dml_plr_obj = DoubleMLPLR$new(obj_dml_data, ml_g, ml_m)
+dml_plr_obj$fit()
+dml_plr_obj$summary()
+```
+
+- State the **result you would have expected** and the **result you actually got**.
+In case of an exception the full traceback is appreciated.
+
+- State the **versions of your code** by running the following lines and copy-paste the result.
+
+```R
+sessionInfo()
+packageVersion('DoubleML')
+packageVersion('mlr3')
+```
+
+## Submit a Feature Request :bulb:
+We welcome **feature requests and suggestions** towards improving and/or extending the DoubleML package.
+For feature requests you can use the corresponding
+[issue template](https://github.com/DoubleML/doubleml-for-r/issues/new/choose).
+
+## Submit a Question or Start a Discussion
+We use **[GitHub Discussions](https://github.com/DoubleML/doubleml-for-r/discussions)** to give the community a platform
+for asking questions about the DoubleML package and for discussions on topics related to the package.
+
+## Contribute Code :computer:
+Everyone is welcome to contribute to the DoubleML code base.
+The following guidelines and hints help you to get started.
+
+### Development Workflow
+In the following, the recommended way to contribute to DoubleML is described in detail.
+The most important steps are: To **fork** the repo, then **add your changes** and finally submit a **pull-request**.
+1. **Fork** the [DoubleML repo](https://github.com/DoubleML/doubleml-for-r)
+by clicking on the Fork button (this requires a GitHub account).
+
+2. **Clone** your fork to your local machine via
+```bash
+$ git clone git@github.com:YourGitHubAccount/doubleml-for-r.git
+$ cd doubleml-for-py
+```
+
+3. Create a **feature branch** via
+```bash
+$ git checkout -b my_feature_branch
+```
+
+4. (Optionally) you can add the `upstream` remote.
+```bash
+$ git remote add upstream https://github.com/DoubleML/doubleml-for-r.git
+```
+This allows you to easily keep your repository in synch via
+```bash
+$ git fetch upstream
+$ git merge upstream/master
+```
+
+5. Install the **development dependencies** via
+TODO: Adapt to R or remove
+
+6. **Install DoubleML in editable mode** (more details can be found ...)
+via 
+TODO: Adapt to R or remove
+
+7. **Develop** your code changes. The changes can be added and pushed via
+```bash
+$ git add your_new_file your_modified_file
+$ git commit -m "A commit message which briefly summarizes the changes made"
+$ git push origin my_feature_branch
+```
+
+8. Generate a **pull request** from your fork.
+Please follow our guidelines for pull requests.
+When opening the PR you will be guided with a checklist.
+
+### Checklist for Pull Requests (PR)
+- [x] The **title** of the pull request summarizes the changes made.
+
+- [x] The PR contains a **detailed description** of all changes and additions
+(you may want to comment on the diff in GitHub).
+
+- [x] **References** to related issues or PRs are added.
+
+- [x] The code passes **all (unit) tests** (see
+[below](https://github.com/DoubleML/doubleml-for-r/blob/master/CONTRIBUTING.md#unit-test-and-test-coverage)
+for details).
+To check, please run
+```bash
+$ pytest .
+```
+
+- [x] If you add an **enhancements** or **new feature**, **unit tests**
+(with a certain level of coverage) are **mandatory** for getting the PR merged.
+
+- [x] Check whether your changes adhere to the **"mlr-style" standards**.
+For the check you can use the following code
+```R
+require(styler)
+remotes::install_github("pat-s/styler@mlr-style")
+styler::style_pkg(style = styler::mlr_style) # entire package
+styler::style_file(<file>, style = styler::mlr_style) # specific file
+```
+
+If your PR is still **work in progress**, please consider marking it a **draft PR**
+(see also [here](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request)).
+
+### Unit Tests and Test Coverage
+TODO: Adapt to R
+
+### Contribute a New Model Class
+The **DoubleML package** is particularly designed in a flexible way to make it **easily extendable** with regard to
+**new model classes**.
+**Contributions** in this direction **are very much welcome**, and we are happy to help authors to integrate their models in the
+DoubleML OOP structure.
+If you need assistance, just open an issue or contact one of the maintainers
+[@MalteKurz](https://github.com/MalteKurz) or [@PhilippBach](https://github.com/PhilippBach).
+
+The **abstract base class `DoubleML` implements all core functionalities** based on a linear Neyman orthogonal score
+function.
+To contribute a new model class, you only need to **specify all nuisance functions** that need to be estimated for the
+new model class (e.g. regressions or classifications).
+Furthermore, the **score components for the Neyman orthogonal score function need to be implemented**.
+All other functionality is automatically available via inheritance from the abstract base class.
+<!---TODO: Add a model template for the R package DoubleML
+A **template for new model classes** is available
+[here](https://github.com/DoubleML/doubleml-docs/blob/master/model_templates/double_ml_model_template.py).--->
+
+## Contribute Documentation :books:
+TODO: Adapt to R
+The **documentation** of DoubleML is generated with **sphinx** and hosted at
+[https://docs.doubleml.org](https://docs.doubleml.org).
+The R API documentation is generated from docstrings in the source code.
+The source code for the website, user guide, example gallery, etc. is available in a separate repository
+[https://github.com/DoubleML/doubleml-docs](https://github.com/DoubleML/doubleml-docs).
+
+### Contribute to the API Documentation
+TODO: Adapt to R
+The **API documentation** is generated from **docstrings** in the source code.
+It can be generated locally (dev requirements sphinx and pydata-sphinx-theme need to be installed) via 
+```bash
+$ cd doc/
+$ make html
+```
+
+### Contribute to the User Guide and Documentation
+The **documentation of DoubleML** is hosted at [https://docs.doubleml.org](https://docs.doubleml.org).
+The **source code** for the website, user guide, example gallery, etc. is available in a **separate repository
+[doubleml-docs](https://github.com/DoubleML/doubleml-docs)**.
+Changes, issues and PRs for the documentation (except the API documentation) should be discussed in the 
+[doubleml-docs](https://github.com/DoubleML/doubleml-docs) repo.
+We welcome contributions to the user guide, especially case studies for the
+[example gallery](https://docs.doubleml.org/stable/examples/index.html).
+A step-by-step guide for contributions to the example gallery is available
+[here](https://github.com/DoubleML/doubleml-docs/wiki/Contribute-to-our-Website-and-Example-Gallery).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,7 +59,7 @@ by clicking on the Fork button (this requires a GitHub account).
 2. **Clone** your fork to your local machine via
 ```bash
 $ git clone git@github.com:YourGitHubAccount/doubleml-for-r.git
-$ cd doubleml-for-py
+$ cd doubleml-for-r
 ```
 
 3. Create a **feature branch** via

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,7 +52,7 @@ The following guidelines and hints help you to get started.
 
 ### Development Workflow
 In the following, the recommended way to contribute to DoubleML is described in detail.
-If you are just starting to work with Git and GitHub, we recommend to read [Happy Git and GitHub for the useR](https://happygitwithr.com/index.html) and the [chapter on Git and GitHub](https://r-pkgs.org/git.html) in Hadley Wickham's book R packages.
+If you are just starting to work with Git and GitHub, we recommend to read [Happy Git and GitHub for the useR](https://happygitwithr.com/index.html) and the [chapter on Git and GitHub](https://r-pkgs.org/git.html) in Hadley Wickham's book R Packages.
 The most important steps are: To **fork** the repo, then **add your changes** and finally submit a **pull-request**.
 1. **Fork** the [DoubleML repo](https://github.com/DoubleML/doubleml-for-r)
 by clicking on the Fork button (this requires a GitHub account).
@@ -127,7 +127,7 @@ If your PR is still **work in progress**, please consider marking it a **draft P
 ### Unit Tests and Test Coverage
 We use the **testthat** package for unit testing.
 Unit testing is considered to be a fundamental part of the development workflow.
-We recommend to read the [chapter on testing](https://r-pkgs.org/tests.html) of Hadley Wickham's book R packages.
+We recommend to read the [chapter on testing](https://r-pkgs.org/tests.html) of Hadley Wickham's book R Packages.
 The tests are located in the `tests/testthat` subfolder.
 The test coverage is determined with the `covr` package.
 Coverage reports for the package, PRs, branches etc. are available from

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,6 +52,7 @@ The following guidelines and hints help you to get started.
 
 ### Development Workflow
 In the following, the recommended way to contribute to DoubleML is described in detail.
+If you are just starting to work with Git and GitHub, we recommend to read [Happy Git and GitHub for the useR](https://happygitwithr.com/index.html) and the [chapter on Git and GitHub](https://r-pkgs.org/git.html) in Hadley Wickham's book R packages.
 The most important steps are: To **fork** the repo, then **add your changes** and finally submit a **pull-request**.
 1. **Fork** the [DoubleML repo](https://github.com/DoubleML/doubleml-for-r)
 by clicking on the Fork button (this requires a GitHub account).
@@ -77,21 +78,16 @@ $ git fetch upstream
 $ git merge upstream/master
 ```
 
-5. Install the **development dependencies** via
-TODO: Adapt to R or remove
-
-6. **Install DoubleML in editable mode** (more details can be found ...)
-via 
-TODO: Adapt to R or remove
-
-7. **Develop** your code changes. The changes can be added and pushed via
+5. **Develop** your code changes. A helpful resource for package development in R
+is Hadley Wickham's [R Packages](https://r-pkgs.org/preface.html).
+The changes can be added and pushed via
 ```bash
 $ git add your_new_file your_modified_file
 $ git commit -m "A commit message which briefly summarizes the changes made"
 $ git push origin my_feature_branch
 ```
 
-8. Generate a **pull request** from your fork.
+6. Generate a **pull request** from your fork.
 Please follow our guidelines for pull requests.
 When opening the PR you will be guided with a checklist.
 
@@ -103,12 +99,14 @@ When opening the PR you will be guided with a checklist.
 
 - [x] **References** to related issues or PRs are added.
 
-- [x] The code passes **all (unit) tests** (see
-[below](https://github.com/DoubleML/doubleml-for-r/blob/master/CONTRIBUTING.md#unit-test-and-test-coverage)
-for details).
-To check, please run
-```bash
-$ pytest .
+- [x] The code passes `R CMD check` and **all (unit) tests**
+To check your code for common problems, run
+```R
+devtools::check()
+```
+In case you only want to run the tests, run
+```R
+devtools::test()
 ```
 
 - [x] If you add an **enhancements** or **new feature**, **unit tests**
@@ -127,7 +125,26 @@ If your PR is still **work in progress**, please consider marking it a **draft P
 (see also [here](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request)).
 
 ### Unit Tests and Test Coverage
-TODO: Adapt to R
+We use the **testthat** package for unit testing.
+Unit testing is considered to be a fundamental part of the development workflow.
+We recommend to read the [chapter on testing](https://r-pkgs.org/tests.html) of Hadley Wickham's book R packages.
+The tests are located in the `tests/testthat` subfolder.
+The test coverage is determined with the `covr` package.
+Coverage reports for the package, PRs, branches etc. are available from
+[codecov](https://app.codecov.io/gh/DoubleML/doubleml-for-r).
+It is mandatory to equip new features with an appropriate level of unit test coverage.
+To **run all unit tests** (for further option see the [devtools docu](https://devtools.r-lib.org/reference/test.html)) call
+```R
+devtools::test()
+```
+For a unit test coverage report you can run
+```R
+covr::report()
+```
+or, alternatively,
+```R
+devtools::test_coverage()
+```
 
 ### Contribute a New Model Class
 The **DoubleML package** is particularly designed in a flexible way to make it **easily extendable** with regard to
@@ -148,20 +165,25 @@ A **template for new model classes** is available
 [here](https://github.com/DoubleML/doubleml-docs/blob/master/model_templates/double_ml_model_template.py).--->
 
 ## Contribute Documentation :books:
-TODO: Adapt to R
-The **documentation** of DoubleML is generated with **sphinx** and hosted at
-[https://docs.doubleml.org](https://docs.doubleml.org).
-The R API documentation is generated from docstrings in the source code.
+
+The **documentation** of DoubleML is generated with **roxygen2**. The corresponding website
+for the R API documentation is generated using **pkgdown** and hosted at
+[https://docs.doubleml.org/r/stable](https://docs.doubleml.org/r/stable/).
+The website [https:://docs.doubleml.org](https://docs.doubleml.org) is built with
+sphinx.
 The source code for the website, user guide, example gallery, etc. is available in a separate repository
 [https://github.com/DoubleML/doubleml-docs](https://github.com/DoubleML/doubleml-docs).
 
 ### Contribute to the API Documentation
-TODO: Adapt to R
-The **API documentation** is generated from **docstrings** in the source code.
-It can be generated locally (dev requirements sphinx and pydata-sphinx-theme need to be installed) via 
-```bash
-$ cd doc/
-$ make html
+The **documentation** of DoubleML is generated with **roxygen2**. The corresponding website
+for the R API documentation is generated using **pkdgdown**.
+To build the documentation of the package run
+```R
+devtools::document()
+```
+To build the documentation website, run (for more details, see the [pkgdown documentation](https://pkgdown.r-lib.org/))
+```R
+pkgdown::build_site()
 ```
 
 ### Contribute to the User Guide and Documentation

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -176,7 +176,7 @@ The source code for the website, user guide, example gallery, etc. is available 
 
 ### Contribute to the API Documentation
 The **documentation** of DoubleML is generated with **roxygen2**. The corresponding website
-for the R API documentation is generated using **pkdgdown**.
+for the R API documentation is generated using **pkgdown**.
 To build the documentation of the package run
 ```R
 devtools::document()

--- a/README.Rmd
+++ b/README.Rmd
@@ -80,6 +80,13 @@ remotes::install_github("DoubleML/doubleml-for-r")
 * clusterGeneration
 * readstata13
 
+## Contributing
+DoubleML is a community effort.
+Everyone is welcome to contribute.
+To get started for your first contribution we recommend reading our
+[contributing guidelines](https://github.com/DoubleML/doubleml-for-r/blob/master/CONTRIBUTING.md)
+and our
+[code of conduct](https://github.com/DoubleML/doubleml-for-r/blob/master/CODE_OF_CONDUCT.md).
 
 ## Citation
 


### PR DESCRIPTION
This PR primarily contains contributing guidelines. Besides that it adds a template for PRs and a code of conduct.

The guidelines and templates are based on those for the [python package] (https://github.com/DoubleML/doubleml-for-py/) and adapted to the workflow in R.