### PR TITLE
Adapt the nuisance estimation for the IV type score in the PLR model

### DIFF
--- a/R/double_ml_plr.R
+++ b/R/double_ml_plr.R
@@ -167,11 +167,11 @@ DoubleMLPLR = R6Class("DoubleMLPLR",
       nuisance = vector("list", self$data$n_treat)
       names(nuisance) = self$data$d_cols
       if ((is.character(self$score) && (self$score == "IV-type")) ||
-          is.function(self$score)) {
-      private$params_ = list(
-        "ml_l" = nuisance,
-        "ml_g" = nuisance,
-        "ml_m" = nuisance)
+        is.function(self$score)) {
+        private$params_ = list(
+          "ml_l" = nuisance,
+          "ml_g" = nuisance,
+          "ml_m" = nuisance)
       } else {
         private$params_ = list(
           "ml_l" = nuisance,
@@ -203,31 +203,31 @@ DoubleMLPLR = R6Class("DoubleMLPLR",
         return_train_preds = FALSE,
         task_type = private$task_type$ml_m,
         fold_specific_params = private$fold_specific_params)
-      
+
       d = self$data$data_model[[self$data$treat_col]]
       y = self$data$data_model[[self$data$y_col]]
-      
+
       g_hat = NULL
       if ((is.character(self$score) && (self$score == "IV-type")) ||
-          is.function(self$score)) {
+        is.function(self$score)) {
         # get an initial estimate for theta using the partialling out score
-        psi_a = - (d - m_hat) * (d - m_hat)
+        psi_a = -(d - m_hat) * (d - m_hat)
         psi_b = (d - m_hat) * (y - l_hat)
-        theta_initial = - mean(psi_b, na.rm = TRUE) / mean(psi_a, na.rm = TRUE)
-        
+        theta_initial = -mean(psi_b, na.rm = TRUE) / mean(psi_a, na.rm = TRUE)
+
         data_aux = data.table(self$data$data_model,
-                              "y_minus_theta_d" = y - theta_initial*d)
-        
+          "y_minus_theta_d" = y - theta_initial * d)
+
         g_hat = dml_cv_predict(self$learner$ml_g,
-                               c(self$data$x_cols, self$data$other_treat_cols),
-                               "y_minus_theta_d",
-                               data_aux,
-                               nuisance_id = "nuis_g",
-                               smpls = smpls,
-                               est_params = self$get_params("ml_g"),
-                               return_train_preds = FALSE,
-                               task_type = private$task_type$ml_g,
-                               fold_specific_params = private$fold_specific_params)
+          c(self$data$x_cols, self$data$other_treat_cols),
+          "y_minus_theta_d",
+          data_aux,
+          nuisance_id = "nuis_g",
+          smpls = smpls,
+          est_params = self$get_params("ml_g"),
+          return_train_preds = FALSE,
+          task_type = private$task_type$ml_g,
+          fold_specific_params = private$fold_specific_params)
       }
 
       res = private$score_elements(y, d, l_hat, g_hat, m_hat, smpls)
@@ -260,6 +260,7 @@ DoubleMLPLR = R6Class("DoubleMLPLR",
     },
     ml_nuisance_tuning = function(smpls, param_set, tune_settings,
       tune_on_folds, ...) {
+
       if (!tune_on_folds) {
         data_tune_list = list(self$data$data_model)
       } else {
@@ -283,7 +284,7 @@ DoubleMLPLR = R6Class("DoubleMLPLR",
         param_set$ml_m, tune_settings,
         tune_settings$measure$ml_m,
         private$task_type$ml_m)
-      
+
       if (self$score == "IV-type") {
         if (tune_on_folds) {
           params_l = tuning_result_l$params
@@ -293,37 +294,37 @@ DoubleMLPLR = R6Class("DoubleMLPLR",
           params_m = tuning_result_m$params[[1]]
         }
         l_hat = dml_cv_predict(self$learner$ml_g,
-                               c(self$data$x_cols, self$data$other_treat_cols),
-                               self$data$y_col,
-                               self$data$data_model,
-                               nuisance_id = "nuis_l",
-                               smpls = smpls,
-                               est_params = params_l,
-                               return_train_preds = FALSE,
-                               task_type = private$task_type$ml_g,
-                               fold_specific_params = private$fold_specific_params)
-        
+          c(self$data$x_cols, self$data$other_treat_cols),
+          self$data$y_col,
+          self$data$data_model,
+          nuisance_id = "nuis_l",
+          smpls = smpls,
+          est_params = params_l,
+          return_train_preds = FALSE,
+          task_type = private$task_type$ml_g,
+          fold_specific_params = private$fold_specific_params)
+
         m_hat = dml_cv_predict(self$learner$ml_m,
-                               c(self$data$x_cols, self$data$other_treat_cols),
-                               self$data$treat_col,
-                               self$data$data_model,
-                               nuisance_id = "nuis_m",
-                               smpls = smpls,
-                               est_params = params_m,
-                               return_train_preds = FALSE,
-                               task_type = private$task_type$ml_m,
-                               fold_specific_params = private$fold_specific_params)
-        
+          c(self$data$x_cols, self$data$other_treat_cols),
+          self$data$treat_col,
+          self$data$data_model,
+          nuisance_id = "nuis_m",
+          smpls = smpls,
+          est_params = params_m,
+          return_train_preds = FALSE,
+          task_type = private$task_type$ml_m,
+          fold_specific_params = private$fold_specific_params)
+
         d = self$data$data_model[[self$data$treat_col]]
         y = self$data$data_model[[self$data$y_col]]
-        
-        psi_a = - (d - m_hat) * (d - m_hat)
+
+        psi_a = -(d - m_hat) * (d - m_hat)
         psi_b = (d - m_hat) * (y - l_hat)
-        theta_initial = - mean(psi_b, na.rm = TRUE) / mean(psi_a, na.rm = TRUE)
-        
+        theta_initial = -mean(psi_b, na.rm = TRUE) / mean(psi_a, na.rm = TRUE)
+
         data_aux = data.table(self$data$data_model,
-                              "y_minus_theta_d" = y - theta_initial*d)
-        
+          "y_minus_theta_d" = y - theta_initial * d)
+
         if (!tune_on_folds) {
           data_aux_tune_list = list(data_aux)
         } else {
@@ -331,14 +332,14 @@ DoubleMLPLR = R6Class("DoubleMLPLR",
             extract_training_data(data_aux, x)
           })
         }
-        
+
         tuning_result_g = dml_tune(self$learner$ml_g,
-                                   c(self$data$x_cols, self$data$other_treat_cols),
-                                   "y_minus_theta_d", data_aux_tune_list,
-                                   nuisance_id = "nuis_g",
-                                   param_set$ml_g, tune_settings,
-                                   tune_settings$measure$ml_g,
-                                   private$task_type$ml_g)
+          c(self$data$x_cols, self$data$other_treat_cols),
+          "y_minus_theta_d", data_aux_tune_list,
+          nuisance_id = "nuis_g",
+          param_set$ml_g, tune_settings,
+          tune_settings$measure$ml_g,
+          private$task_type$ml_g)
         tuning_result = list(
           "ml_l" = list(tuning_result_l, params = tuning_result_l$params),
           "ml_g" = list(tuning_result_g, params = tuning_result_g$params),
@@ -348,7 +349,7 @@ DoubleMLPLR = R6Class("DoubleMLPLR",
           "ml_l" = list(tuning_result_l, params = tuning_result_l$params),
           "ml_m" = list(tuning_result_m, params = tuning_result_m$params))
       }
-      
+
       return(tuning_result)
     },
     check_score = function(score) {

--- a/R/double_ml_plr.R
+++ b/R/double_ml_plr.R
@@ -166,7 +166,7 @@ DoubleMLPLR = R6Class("DoubleMLPLR",
     initialize_ml_nuisance_params = function() {
       nuisance = vector("list", self$data$n_treat)
       names(nuisance) = self$data$d_cols
-      if ((is.character(self$score) & self$score == "IV-type") |
+      if ((is.character(self$score) && (self$score == "IV-type")) ||
           is.function(self$score)) {
       private$params_ = list(
         "ml_l" = nuisance,
@@ -208,12 +208,12 @@ DoubleMLPLR = R6Class("DoubleMLPLR",
       y = self$data$data_model[[self$data$y_col]]
       
       g_hat = NULL
-      if ((is.character(self$score) & self$score == "IV-type") |
+      if ((is.character(self$score) && (self$score == "IV-type")) ||
           is.function(self$score)) {
         # get an initial estimate for theta using the partialling out score
         psi_a = - (d - m_hat) * (d - m_hat)
         psi_b = (d - m_hat) * (y - l_hat)
-        theta_initial = -mean(psi_b) / mean(psi_a)
+        theta_initial = - mean(psi_b, na.rm = TRUE) / mean(psi_a, na.rm = TRUE)
         
         data_aux = data.table(self$data$data_model,
                               "y_minus_theta_d" = y - theta_initial*d)

--- a/man/DoubleMLPLR.Rd
+++ b/man/DoubleMLPLR.Rd
@@ -139,7 +139,8 @@ Alternatively, a \code{\link[mlr3:Learner]{Learner}} object with public field
 \code{\link[mlr3pipelines:mlr_learners_graph]{GraphLearner}}. The learner can possibly
 be passed with specified parameters, for example
 \code{lrn("regr.cv_glmnet", s = "lambda.min")}. \cr
-\code{ml_g} refers to the nuisance function \eqn{g_0(X) = E[Y|X]}.}
+\code{ml_g} refers to the nuisance functions \eqn{l_0(X) = E[Y|X]} and
+\eqn{g_0(X) = E[Y - D\theta_0|X]}.}
 
 \item{\code{ml_m}}{(\code{\link[mlr3:LearnerRegr]{LearnerRegr}},
 \code{\link[mlr3:LearnerClassif]{LearnerClassif}}, \code{\link[mlr3:Learner]{Learner}},
@@ -167,7 +168,7 @@ Number of repetitions for the sample splitting. Default is \code{1}.}
 A \code{character(1)} (\code{"partialling out"} or \code{IV-type}) or a \verb{function()}
 specifying the score function.
 If a \verb{function()} is provided, it must be of the form
-\verb{function(y, d, g_hat, m_hat, smpls)} and
+\verb{function(y, d, l_hat, g_hat, m_hat, smpls)} and
 the returned output must be a named \code{list()} with elements \code{psi_a} and
 \code{psi_b}. Default is \code{"partialling out"}.}
 

--- a/tests/testthat/helper-08-dml_plr.R
+++ b/tests/testthat/helper-08-dml_plr.R
@@ -265,7 +265,7 @@ fit_nuisance_plr = function(data, y, d,
     d_minus_m_hat = residuals$d_minus_m_hat
     psi_a = - d_minus_m_hat*d_minus_m_hat
     psi_b = d_minus_m_hat*y_minus_l_hat
-    theta_initial = -mean(psi_b) / mean(psi_a)
+    theta_initial = - mean(psi_b, na.rm = TRUE) / mean(psi_a, na.rm = TRUE)
     
     D = data[, d]
     Y = data[, y]

--- a/tests/testthat/helper-08-dml_plr.R
+++ b/tests/testthat/helper-08-dml_plr.R
@@ -179,7 +179,7 @@ fit_plr_single_split = function(data, y, d,
   if (dml_procedure == "dml2") {
     orth_est = orth_plr_dml(
       y_minus_l_hat = y_minus_l_hat,
-      y_minus_g_hat = y_minus_g_hat, 
+      y_minus_g_hat = y_minus_g_hat,
       d_minus_m_hat = d_minus_m_hat,
       d = D, score = score)
     theta = orth_est$theta
@@ -211,8 +211,9 @@ fit_nuisance_plr = function(data, y, d,
   # nuisance l
   l_indx = names(data) != d
   data_l = data[, l_indx, drop = FALSE]
-  task_l = mlr3::TaskRegr$new(id = paste0("nuis_l_", d),
-                              backend = data_l, target = y)
+  task_l = mlr3::TaskRegr$new(
+    id = paste0("nuis_l_", d),
+    backend = data_l, target = y)
 
   resampling_l = mlr3::rsmp("custom")
   resampling_l$instantiate(task_l, train_ids, test_ids)
@@ -252,7 +253,7 @@ fit_nuisance_plr = function(data, y, d,
     r_m = mlr3::resample(task_m, ml_m, resampling_m, store_models = TRUE)
     m_hat_list = lapply(r_m$predictions(), function(x) as.data.table(x)$prob.1)
   }
-  
+
   if (fit_g) {
     # nuisance g
     residuals = compute_plr_residuals(
@@ -263,26 +264,27 @@ fit_nuisance_plr = function(data, y, d,
         m_hat_list = m_hat_list))
     y_minus_l_hat = residuals$y_minus_l_hat
     d_minus_m_hat = residuals$d_minus_m_hat
-    psi_a = - d_minus_m_hat*d_minus_m_hat
-    psi_b = d_minus_m_hat*y_minus_l_hat
-    theta_initial = - mean(psi_b, na.rm = TRUE) / mean(psi_a, na.rm = TRUE)
-    
+    psi_a = -d_minus_m_hat * d_minus_m_hat
+    psi_b = d_minus_m_hat * y_minus_l_hat
+    theta_initial = -mean(psi_b, na.rm = TRUE) / mean(psi_a, na.rm = TRUE)
+
     D = data[, d]
     Y = data[, y]
     g_indx = names(data) != y & names(data) != d
-    y_minus_theta_d = Y - theta_initial*D
+    y_minus_theta_d = Y - theta_initial * D
     data_g = cbind(data[, g_indx, drop = FALSE], y_minus_theta_d)
-    
-    task_g = mlr3::TaskRegr$new(id = paste0("nuis_g_", d), backend = data_g,
-                                target = "y_minus_theta_d")
-    
+
+    task_g = mlr3::TaskRegr$new(
+      id = paste0("nuis_g_", d), backend = data_g,
+      target = "y_minus_theta_d")
+
     resampling_g = mlr3::rsmp("custom")
     resampling_g$instantiate(task_g, train_ids, test_ids)
-    
+
     if (!is.null(params_g)) {
       ml_g$param_set$values = params_g
     }
-    
+
     r_g = mlr3::resample(task_g, ml_g, resampling_g, store_models = TRUE)
     g_hat_list = lapply(r_g$predictions(), function(x) x$response)
   } else {
@@ -300,7 +302,7 @@ fit_nuisance_plr = function(data, y, d,
 compute_plr_residuals = function(data, y, d, n_folds, smpls, all_preds) {
 
   test_ids = smpls$test_ids
-  
+
   l_hat_list = all_preds$l_hat_list
   g_hat_list = all_preds$g_hat_list
   m_hat_list = all_preds$m_hat_list
@@ -313,21 +315,22 @@ compute_plr_residuals = function(data, y, d, n_folds, smpls, all_preds) {
 
   for (i in 1:n_folds) {
     test_index = test_ids[[i]]
-    
+
     l_hat = l_hat_list[[i]]
     m_hat = m_hat_list[[i]]
 
     y_minus_l_hat[test_index] = Y[test_index] - l_hat
     d_minus_m_hat[test_index] = D[test_index] - m_hat
-    
+
     if (!is.null(g_hat_list)) {
       g_hat = g_hat_list[[i]]
       y_minus_g_hat[test_index] = Y[test_index] - g_hat
     }
   }
-  residuals = list(y_minus_l_hat = y_minus_l_hat,
-                   y_minus_g_hat = y_minus_g_hat,
-                   d_minus_m_hat = d_minus_m_hat)
+  residuals = list(
+    y_minus_l_hat = y_minus_l_hat,
+    y_minus_g_hat = y_minus_g_hat,
+    d_minus_m_hat = d_minus_m_hat)
 
   return(residuals)
 }
@@ -436,7 +439,7 @@ boot_plr_single_split = function(theta, se, data, y, d,
   y_minus_l_hat = residuals$y_minus_l_hat
   y_minus_g_hat = residuals$y_minus_g_hat
   d_minus_m_hat = residuals$d_minus_m_hat
-  
+
   D = data[, d]
 
   if (score == "partialling out") {

--- a/tests/testthat/test-double_ml_plr_exception_handling.R
+++ b/tests/testthat/test-double_ml_plr_exception_handling.R
@@ -81,15 +81,15 @@ patrick::with_parameters_test_that("Unit tests for exception handling of PLR:",
           learner = "ml_l",
           treat_var = "d",
           params = learner_pars$params$params_g)
-        
-        if (score == 'IV-type') {
+
+        if (score == "IV-type") {
           # set params for nuisance part g
           double_mlplr_obj$set_ml_nuisance_params(
             learner = "ml_g",
             treat_var = "d",
             params = learner_pars$params$params_g)
         }
-        
+
       }
 
       # currently, no warning or message printed

--- a/tests/testthat/test-double_ml_plr_exception_handling.R
+++ b/tests/testthat/test-double_ml_plr_exception_handling.R
@@ -76,11 +76,20 @@ patrick::with_parameters_test_that("Unit tests for exception handling of PLR:",
           treat_var = "d",
           params = learner_pars$params$params_m)
 
-        # set params for nuisance part g
+        # set params for nuisance part l
         double_mlplr_obj$set_ml_nuisance_params(
-          learner = "ml_g",
+          learner = "ml_l",
           treat_var = "d",
           params = learner_pars$params$params_g)
+        
+        if (score == 'IV-type') {
+          # set params for nuisance part g
+          double_mlplr_obj$set_ml_nuisance_params(
+            learner = "ml_g",
+            treat_var = "d",
+            params = learner_pars$params$params_g)
+        }
+        
       }
 
       # currently, no warning or message printed

--- a/tests/testthat/test-double_ml_plr_export_preds.R
+++ b/tests/testthat/test-double_ml_plr_export_preds.R
@@ -17,7 +17,7 @@ if (on_cran) {
     g_learner = c("regr.rpart", "regr.lm"),
     m_learner = c("regr.rpart", "regr.lm"),
     dml_procedure = "dml2",
-    score = "partialling out",
+    score = c("partialling out", "IV-type"),
     stringsAsFactors = FALSE)
 }
 test_cases[".test_name"] = apply(test_cases, 1, paste, collapse = "_")
@@ -65,7 +65,9 @@ patrick::with_parameters_test_that("Unit tests for for the export of predictions
     preds_m = as.data.table(resampling_pred$prediction())
     data.table::setorder(preds_m, "row_ids")
 
-    expect_equal(as.vector(double_mlplr_obj$predictions$ml_g),
+    # TODO: extend for IV-type score to g_hat and l_hat
+    
+    expect_equal(as.vector(double_mlplr_obj$predictions$ml_l),
       as.vector(preds_g$response),
       tolerance = 1e-8)
 

--- a/tests/testthat/test-double_ml_plr_export_preds.R
+++ b/tests/testthat/test-double_ml_plr_export_preds.R
@@ -66,7 +66,7 @@ patrick::with_parameters_test_that("Unit tests for for the export of predictions
     data.table::setorder(preds_m, "row_ids")
 
     # TODO: extend for IV-type score to g_hat and l_hat
-    
+
     expect_equal(as.vector(double_mlplr_obj$predictions$ml_l),
       as.vector(preds_g$response),
       tolerance = 1e-8)

--- a/tests/testthat/test-double_ml_plr_loaded_mlr3learner.R
+++ b/tests/testthat/test-double_ml_plr_loaded_mlr3learner.R
@@ -43,11 +43,19 @@ patrick::with_parameters_test_that("Unit tests for PLR:",
       treat_var = "d",
       params = params)
 
-    # set params for nuisance part g
+    # set params for nuisance part l
     double_mlplr$set_ml_nuisance_params(
-      learner = "ml_g",
+      learner = "ml_l",
       treat_var = "d",
       params = params)
+    
+    if (score == "IV-type") {
+      # set params for nuisance part g
+      double_mlplr$set_ml_nuisance_params(
+        learner = "ml_g",
+        treat_var = "d",
+        params = params)
+    }
 
     double_mlplr$fit()
     theta = double_mlplr$coef
@@ -92,11 +100,19 @@ patrick::with_parameters_test_that("Unit tests for PLR:",
       treat_var = "d",
       params = params)
 
-    # set params for nuisance part g
+    # set params for nuisance part l
     double_mlplr_semiloaded$set_ml_nuisance_params(
-      learner = "ml_g",
+      learner = "ml_l",
       treat_var = "d",
       params = params)
+    
+    if (score == "IV-type") {
+      # set params for nuisance part g
+      double_mlplr_semiloaded$set_ml_nuisance_params(
+        learner = "ml_g",
+        treat_var = "d",
+        params = params)
+    }
 
     double_mlplr_semiloaded$fit()
     theta_semiloaded = double_mlplr_semiloaded$coef

--- a/tests/testthat/test-double_ml_plr_loaded_mlr3learner.R
+++ b/tests/testthat/test-double_ml_plr_loaded_mlr3learner.R
@@ -48,7 +48,7 @@ patrick::with_parameters_test_that("Unit tests for PLR:",
       learner = "ml_l",
       treat_var = "d",
       params = params)
-    
+
     if (score == "IV-type") {
       # set params for nuisance part g
       double_mlplr$set_ml_nuisance_params(
@@ -105,7 +105,7 @@ patrick::with_parameters_test_that("Unit tests for PLR:",
       learner = "ml_l",
       treat_var = "d",
       params = params)
-    
+
     if (score == "IV-type") {
       # set params for nuisance part g
       double_mlplr_semiloaded$set_ml_nuisance_params(

--- a/tests/testthat/test-double_ml_plr_nonorth.R
+++ b/tests/testthat/test-double_ml_plr_nonorth.R
@@ -4,7 +4,7 @@ library("mlr3learners")
 
 lgr::get_logger("mlr3")$set_threshold("warn")
 
-non_orth_score = function(y, d, g_hat, m_hat, smpls) {
+non_orth_score = function(y, d, l_hat, g_hat, m_hat, smpls) {
   u_hat = y - g_hat
   psi_a = -1 * d * d
   psi_b = d * u_hat

--- a/tests/testthat/test-double_ml_plr_parameter_passing.R
+++ b/tests/testthat/test-double_ml_plr_parameter_passing.R
@@ -74,10 +74,10 @@ patrick::with_parameters_test_that("Unit tests for parameter passing of PLR (oop
       n_rep = n_rep)
 
     double_mlplr_obj$set_ml_nuisance_params(
-      treat_var = "d1", learner = "ml_g",
+      treat_var = "d1", learner = "ml_l",
       params = learner_pars$params$params_g)
     double_mlplr_obj$set_ml_nuisance_params(
-      treat_var = "d2", learner = "ml_g",
+      treat_var = "d2", learner = "ml_l",
       params = learner_pars$params$params_g)
     double_mlplr_obj$set_ml_nuisance_params(
       treat_var = "d1", learner = "ml_m",
@@ -85,6 +85,14 @@ patrick::with_parameters_test_that("Unit tests for parameter passing of PLR (oop
     double_mlplr_obj$set_ml_nuisance_params(
       treat_var = "d2", learner = "ml_m",
       params = learner_pars$params$params_m)
+    if (score == 'IV-type') {
+      double_mlplr_obj$set_ml_nuisance_params(
+        treat_var = "d1", learner = "ml_g",
+        params = learner_pars$params$params_g)
+      double_mlplr_obj$set_ml_nuisance_params(
+        treat_var = "d2", learner = "ml_g",
+        params = learner_pars$params$params_g)
+    }
 
 
     double_mlplr_obj$fit()
@@ -146,10 +154,10 @@ patrick::with_parameters_test_that("Unit tests for parameter passing of PLR (no 
       apply_cross_fitting = FALSE)
 
     double_mlplr_obj_nocf$set_ml_nuisance_params(
-      treat_var = "d1", learner = "ml_g",
+      treat_var = "d1", learner = "ml_l",
       params = learner_pars$params$params_g)
     double_mlplr_obj_nocf$set_ml_nuisance_params(
-      treat_var = "d2", learner = "ml_g",
+      treat_var = "d2", learner = "ml_l",
       params = learner_pars$params$params_g)
     double_mlplr_obj_nocf$set_ml_nuisance_params(
       treat_var = "d1", learner = "ml_m",
@@ -157,6 +165,14 @@ patrick::with_parameters_test_that("Unit tests for parameter passing of PLR (no 
     double_mlplr_obj_nocf$set_ml_nuisance_params(
       treat_var = "d2", learner = "ml_m",
       params = learner_pars$params$params_m)
+    if (score == 'IV-type') {
+      double_mlplr_obj_nocf$set_ml_nuisance_params(
+        treat_var = "d1", learner = "ml_g",
+        params = learner_pars$params$params_g)
+      double_mlplr_obj_nocf$set_ml_nuisance_params(
+        treat_var = "d2", learner = "ml_g",
+        params = learner_pars$params$params_g)
+    }
 
 
     double_mlplr_obj_nocf$fit()
@@ -191,10 +207,10 @@ patrick::with_parameters_test_that("Unit tests for parameter passing of PLR (fol
       n_rep = n_rep)
 
     double_mlplr_obj$set_ml_nuisance_params(
-      treat_var = "d1", learner = "ml_g",
+      treat_var = "d1", learner = "ml_l",
       params = learner_pars$params$params_g)
     double_mlplr_obj$set_ml_nuisance_params(
-      treat_var = "d2", learner = "ml_g",
+      treat_var = "d2", learner = "ml_l",
       params = learner_pars$params$params_g)
     double_mlplr_obj$set_ml_nuisance_params(
       treat_var = "d1", learner = "ml_m",
@@ -202,6 +218,14 @@ patrick::with_parameters_test_that("Unit tests for parameter passing of PLR (fol
     double_mlplr_obj$set_ml_nuisance_params(
       treat_var = "d2", learner = "ml_m",
       params = learner_pars$params$params_m)
+    if (score == 'IV-type') {
+      double_mlplr_obj$set_ml_nuisance_params(
+        treat_var = "d1", learner = "ml_g",
+        params = learner_pars$params$params_g)
+      double_mlplr_obj$set_ml_nuisance_params(
+        treat_var = "d2", learner = "ml_g",
+        params = learner_pars$params$params_g)
+    }
 
     double_mlplr_obj$fit()
     theta = double_mlplr_obj$coef
@@ -220,11 +244,11 @@ patrick::with_parameters_test_that("Unit tests for parameter passing of PLR (fol
       n_rep = n_rep)
 
     dml_plr_fold_wise$set_ml_nuisance_params(
-      treat_var = "d1", learner = "ml_g",
+      treat_var = "d1", learner = "ml_l",
       params = params_g_fold_wise,
       set_fold_specific = TRUE)
     dml_plr_fold_wise$set_ml_nuisance_params(
-      treat_var = "d2", learner = "ml_g",
+      treat_var = "d2", learner = "ml_l",
       params = params_g_fold_wise,
       set_fold_specific = TRUE)
     dml_plr_fold_wise$set_ml_nuisance_params(
@@ -235,6 +259,16 @@ patrick::with_parameters_test_that("Unit tests for parameter passing of PLR (fol
       treat_var = "d2", learner = "ml_m",
       params = params_m_fold_wise,
       set_fold_specific = TRUE)
+    if (score == 'IV-type') {
+      dml_plr_fold_wise$set_ml_nuisance_params(
+        treat_var = "d1", learner = "ml_g",
+        params = params_g_fold_wise,
+        set_fold_specific = TRUE)
+      dml_plr_fold_wise$set_ml_nuisance_params(
+        treat_var = "d2", learner = "ml_g",
+        params = params_g_fold_wise,
+        set_fold_specific = TRUE)
+    }
 
     dml_plr_fold_wise$fit()
     theta_fold_wise = dml_plr_fold_wise$coef
@@ -281,10 +315,10 @@ patrick::with_parameters_test_that("Unit tests for parameter passing of PLR (def
       score = score,
       n_rep = n_rep)
     double_mlplr_obj$set_ml_nuisance_params(
-      treat_var = "d1", learner = "ml_g",
+      treat_var = "d1", learner = "ml_l",
       params = params_g)
     double_mlplr_obj$set_ml_nuisance_params(
-      treat_var = "d2", learner = "ml_g",
+      treat_var = "d2", learner = "ml_l",
       params = params_g)
     double_mlplr_obj$set_ml_nuisance_params(
       treat_var = "d1", learner = "ml_m",
@@ -292,6 +326,14 @@ patrick::with_parameters_test_that("Unit tests for parameter passing of PLR (def
     double_mlplr_obj$set_ml_nuisance_params(
       treat_var = "d2", learner = "ml_m",
       params = params_m)
+    if (score == 'IV-type') {
+      double_mlplr_obj$set_ml_nuisance_params(
+        treat_var = "d1", learner = "ml_g",
+        params = params_g)
+      double_mlplr_obj$set_ml_nuisance_params(
+        treat_var = "d2", learner = "ml_g",
+        params = params_g)
+    }
 
     double_mlplr_obj$fit()
     theta = double_mlplr_obj$coef

--- a/tests/testthat/test-double_ml_plr_parameter_passing.R
+++ b/tests/testthat/test-double_ml_plr_parameter_passing.R
@@ -85,7 +85,7 @@ patrick::with_parameters_test_that("Unit tests for parameter passing of PLR (oop
     double_mlplr_obj$set_ml_nuisance_params(
       treat_var = "d2", learner = "ml_m",
       params = learner_pars$params$params_m)
-    if (score == 'IV-type') {
+    if (score == "IV-type") {
       double_mlplr_obj$set_ml_nuisance_params(
         treat_var = "d1", learner = "ml_g",
         params = learner_pars$params$params_g)
@@ -165,7 +165,7 @@ patrick::with_parameters_test_that("Unit tests for parameter passing of PLR (no 
     double_mlplr_obj_nocf$set_ml_nuisance_params(
       treat_var = "d2", learner = "ml_m",
       params = learner_pars$params$params_m)
-    if (score == 'IV-type') {
+    if (score == "IV-type") {
       double_mlplr_obj_nocf$set_ml_nuisance_params(
         treat_var = "d1", learner = "ml_g",
         params = learner_pars$params$params_g)
@@ -218,7 +218,7 @@ patrick::with_parameters_test_that("Unit tests for parameter passing of PLR (fol
     double_mlplr_obj$set_ml_nuisance_params(
       treat_var = "d2", learner = "ml_m",
       params = learner_pars$params$params_m)
-    if (score == 'IV-type') {
+    if (score == "IV-type") {
       double_mlplr_obj$set_ml_nuisance_params(
         treat_var = "d1", learner = "ml_g",
         params = learner_pars$params$params_g)
@@ -259,7 +259,7 @@ patrick::with_parameters_test_that("Unit tests for parameter passing of PLR (fol
       treat_var = "d2", learner = "ml_m",
       params = params_m_fold_wise,
       set_fold_specific = TRUE)
-    if (score == 'IV-type') {
+    if (score == "IV-type") {
       dml_plr_fold_wise$set_ml_nuisance_params(
         treat_var = "d1", learner = "ml_g",
         params = params_g_fold_wise,
@@ -326,7 +326,7 @@ patrick::with_parameters_test_that("Unit tests for parameter passing of PLR (def
     double_mlplr_obj$set_ml_nuisance_params(
       treat_var = "d2", learner = "ml_m",
       params = params_m)
-    if (score == 'IV-type') {
+    if (score == "IV-type") {
       double_mlplr_obj$set_ml_nuisance_params(
         treat_var = "d1", learner = "ml_g",
         params = params_g)

--- a/tests/testthat/test-double_ml_plr_user_score.R
+++ b/tests/testthat/test-double_ml_plr_user_score.R
@@ -4,9 +4,9 @@ library("mlr3learners")
 
 lgr::get_logger("mlr3")$set_threshold("warn")
 
-score_fct = function(y, d, g_hat, m_hat, smpls) {
+score_fct = function(y, d, l_hat, g_hat, m_hat, smpls) {
   v_hat = d - m_hat
-  u_hat = y - g_hat
+  u_hat = y - l_hat
   v_hatd = v_hat * d
   psi_a = -v_hat * v_hat
   psi_b = v_hat * u_hat


### PR DESCRIPTION
### Description
In this PR the nuisance estimation for the IV-type score in the PLR model is adapted to be in line with the DML paper [Chernozhukov et al. (2018)](https://doi.org/10.1111/ectj.12097).
* Results for the default `score='partialling out'` (Equation (4.4) in [Chernozhukov et al. (2018)](https://doi.org/10.1111/ectj.12097)) are not affected by the changes in this PR. However, the naming of the predictions is changed from `g_hat` to `l_hat` to be better in line with [Chernozhukov et al. (2018)](https://doi.org/10.1111/ectj.12097). Still the API is not changed to be backward-compatible, i.e., when initializing an `DoubleMLPLR` object, learners `ml_g` and `ml_m` need to be specified. The estimator `ml_g` is then used to estimate the effect of `X` on `Y` (i.e. l_0(X) = E[Y|X]) and the estimator `ml_m` to estimate the effect of `X` on `D` (i.e. m_0(X) = E[D|X]). When setting hyperparamters `learner='ml_l'` and `learner='ml_m'` should be used.
* For the `score='IV-type'` (Equation (4.3) in [Chernozhukov et al. (2018)](https://doi.org/10.1111/ectj.12097)) the implementation now follows the approach described on pp. C31-C33 in [Chernozhukov et al. (2018)](https://doi.org/10.1111/ectj.12097). This means that an initial estimate for `theta_0` is obtained via the `'partialling out'` score. Then an estimate for `g_0(X)` is obtained by regressing `Y - theta_0 * D` on `X`. For both nuisance functions `l_0(X)` (needed for the preliminary `theta_0` estimate) and `g_0(X)`, the same ML estimator (specified in `ml_g`) is used. However, hyperparamters can be set individually via `learner='ml_l'` and `learner='ml_m'`.

### PR Checklist

- [x] The title of the pull request summarizes the changes made.
- [x] The PR contains a detailed description of all changes and additions.
- [x] References to related issues or PRs are added.
- [x] The code passes `R CMD check` and all (unit) tests (see our [contributing guidelines](https://github.com/DoubleML/doubleml-for-r/blob/master/CONTRIBUTING.md#checklist-for-pull-requests-pr) for details).
- [x] Enhancements or new feature are equipped with unit tests.
- [x] The changes adhere to the "mlr-style" standards (see our [contributing guidelines](https://github.com/DoubleML/doubleml-for-r/blob/master/CONTRIBUTING.md#checklist-for-pull-requests-pr) for details).
