### PR TITLE
Compatibility with upcoming paradox CRAN release

### DIFF
--- a/.github/workflows/rcheck.yml
+++ b/.github/workflows/rcheck.yml
@@ -78,6 +78,7 @@ jobs:
         if: matrix.config.mlr3 == 'dev'
         run: |
           remotes::install_github("mlr-org/mlr3")
+          remotes::install_github("mlr-org/paradox")
         shell: Rscript {0}
 
       - name: Check

--- a/R/double_ml_iivm.R
+++ b/R/double_ml_iivm.R
@@ -74,15 +74,15 @@
 #'   alpha_x = 1, dim_x = 20)
 #' dml_iivm_obj = DoubleMLIIVM$new(obj_dml_data, ml_g, ml_m, ml_r)
 #' param_grid = list(
-#'   "ml_g" = paradox::ParamSet$new(list(
-#'     paradox::ParamDbl$new("cp", lower = 0.01, upper = 0.02),
-#'     paradox::ParamInt$new("minsplit", lower = 1, upper = 2))),
-#'   "ml_m" = paradox::ParamSet$new(list(
-#'     paradox::ParamDbl$new("cp", lower = 0.01, upper = 0.02),
-#'     paradox::ParamInt$new("minsplit", lower = 1, upper = 2))),
-#'   "ml_r" = paradox::ParamSet$new(list(
-#'     paradox::ParamDbl$new("cp", lower = 0.01, upper = 0.02),
-#'     paradox::ParamInt$new("minsplit", lower = 1, upper = 2))))
+#'   "ml_g" = paradox::ps(
+#'     cp = paradox::p_dbl(lower = 0.01, upper = 0.02),
+#'     minsplit = paradox::p_int(lower = 1, upper = 2)),
+#'   "ml_m" = paradox::ps(
+#'     cp = paradox::p_dbl(lower = 0.01, upper = 0.02),
+#'     minsplit = paradox::p_int(lower = 1, upper = 2)),
+#'   "ml_r" = paradox::ps(
+#'     cp = paradox::p_dbl(lower = 0.01, upper = 0.02),
+#'     minsplit = paradox::p_int(lower = 1, upper = 2)))
 #' # minimum requirements for tune_settings
 #' tune_settings = list(
 #'   terminator = mlr3tuning::trm("evals", n_evals = 5),

--- a/R/double_ml_irm.R
+++ b/R/double_ml_irm.R
@@ -59,12 +59,12 @@
 #' dml_irm_obj = DoubleMLIRM$new(obj_dml_data, ml_g, ml_m)
 #'
 #' param_grid = list(
-#'   "ml_g" = paradox::ParamSet$new(list(
-#'     paradox::ParamDbl$new("cp", lower = 0.01, upper = 0.02),
-#'     paradox::ParamInt$new("minsplit", lower = 1, upper = 2))),
-#'   "ml_m" = paradox::ParamSet$new(list(
-#'     paradox::ParamDbl$new("cp", lower = 0.01, upper = 0.02),
-#'     paradox::ParamInt$new("minsplit", lower = 1, upper = 2))))
+#'   "ml_g" = paradox::ps(
+#'     cp = paradox::p_dbl(lower = 0.01, upper = 0.02),
+#'     minsplit = paradox::p_int(lower = 1, upper = 2)),
+#'   "ml_m" = paradox::ps(
+#'     cp = paradox::p_dbl(lower = 0.01, upper = 0.02),
+#'     minsplit = paradox::p_int(lower = 1, upper = 2)))
 #'
 #' # minimum requirements for tune_settings
 #' tune_settings = list(

--- a/R/double_ml_pliv.R
+++ b/R/double_ml_pliv.R
@@ -49,15 +49,15 @@
 #'   dim_z = 1)
 #' dml_pliv_obj = DoubleMLPLIV$new(obj_dml_data, ml_l, ml_m, ml_r)
 #' param_grid = list(
-#'   "ml_l" = paradox::ParamSet$new(list(
-#'     paradox::ParamDbl$new("cp", lower = 0.01, upper = 0.02),
-#'     paradox::ParamInt$new("minsplit", lower = 1, upper = 2))),
-#'   "ml_m" = paradox::ParamSet$new(list(
-#'     paradox::ParamDbl$new("cp", lower = 0.01, upper = 0.02),
-#'     paradox::ParamInt$new("minsplit", lower = 1, upper = 2))),
-#'   "ml_r" = paradox::ParamSet$new(list(
-#'     paradox::ParamDbl$new("cp", lower = 0.01, upper = 0.02),
-#'     paradox::ParamInt$new("minsplit", lower = 1, upper = 2))))
+#'   "ml_l" = paradox::ps(
+#'     cp = paradox::p_dbl(lower = 0.01, upper = 0.02),
+#'     minsplit = paradox::p_int(lower = 1, upper = 2)),
+#'   "ml_m" = paradox::ps(
+#'     cp = paradox::p_dbl(lower = 0.01, upper = 0.02),
+#'     minsplit = paradox::p_int(lower = 1, upper = 2)),
+#'   "ml_r" = paradox::ps(
+#'     cp = paradox::p_dbl(lower = 0.01, upper = 0.02),
+#'     minsplit = paradox::p_int(lower = 1, upper = 2)))
 #'
 #' # minimum requirements for tune_settings
 #' tune_settings = list(

--- a/R/double_ml_plr.R
+++ b/R/double_ml_plr.R
@@ -48,12 +48,12 @@
 #' dml_plr_obj = DoubleMLPLR$new(obj_dml_data, ml_l, ml_m)
 #'
 #' param_grid = list(
-#'   "ml_l" = paradox::ParamSet$new(list(
-#'     paradox::ParamDbl$new("cp", lower = 0.01, upper = 0.02),
-#'     paradox::ParamInt$new("minsplit", lower = 1, upper = 2))),
-#'   "ml_m" = paradox::ParamSet$new(list(
-#'     paradox::ParamDbl$new("cp", lower = 0.01, upper = 0.02),
-#'     paradox::ParamInt$new("minsplit", lower = 1, upper = 2))))
+#'   "ml_l" = paradox::ps(
+#'     cp = paradox::p_dbl(lower = 0.01, upper = 0.02),
+#'     minsplit = paradox::p_int(lower = 1, upper = 2)),
+#'   "ml_m" = paradox::ps(
+#'     cp = paradox::p_dbl(lower = 0.01, upper = 0.02),
+#'     minsplit = paradox::p_int(lower = 1, upper = 2)))
 #'
 #' # minimum requirements for tune_settings
 #' tune_settings = list(

--- a/man/DoubleMLIIVM.Rd
+++ b/man/DoubleMLIIVM.Rd
@@ -73,15 +73,15 @@ obj_dml_data = make_iivm_data(
   alpha_x = 1, dim_x = 20)
 dml_iivm_obj = DoubleMLIIVM$new(obj_dml_data, ml_g, ml_m, ml_r)
 param_grid = list(
-  "ml_g" = paradox::ParamSet$new(list(
-    paradox::ParamDbl$new("cp", lower = 0.01, upper = 0.02),
-    paradox::ParamInt$new("minsplit", lower = 1, upper = 2))),
-  "ml_m" = paradox::ParamSet$new(list(
-    paradox::ParamDbl$new("cp", lower = 0.01, upper = 0.02),
-    paradox::ParamInt$new("minsplit", lower = 1, upper = 2))),
-  "ml_r" = paradox::ParamSet$new(list(
-    paradox::ParamDbl$new("cp", lower = 0.01, upper = 0.02),
-    paradox::ParamInt$new("minsplit", lower = 1, upper = 2))))
+  "ml_g" = paradox::ps(
+    cp = paradox::p_dbl(lower = 0.01, upper = 0.02),
+    minsplit = paradox::p_int(lower = 1, upper = 2)),
+  "ml_m" = paradox::ps(
+    cp = paradox::p_dbl(lower = 0.01, upper = 0.02),
+    minsplit = paradox::p_int(lower = 1, upper = 2)),
+  "ml_r" = paradox::ps(
+    cp = paradox::p_dbl(lower = 0.01, upper = 0.02),
+    minsplit = paradox::p_int(lower = 1, upper = 2)))
 # minimum requirements for tune_settings
 tune_settings = list(
   terminator = mlr3tuning::trm("evals", n_evals = 5),

--- a/man/DoubleMLIRM.Rd
+++ b/man/DoubleMLIRM.Rd
@@ -59,12 +59,12 @@ obj_dml_data = make_irm_data(theta = 0.5)
 dml_irm_obj = DoubleMLIRM$new(obj_dml_data, ml_g, ml_m)
 
 param_grid = list(
-  "ml_g" = paradox::ParamSet$new(list(
-    paradox::ParamDbl$new("cp", lower = 0.01, upper = 0.02),
-    paradox::ParamInt$new("minsplit", lower = 1, upper = 2))),
-  "ml_m" = paradox::ParamSet$new(list(
-    paradox::ParamDbl$new("cp", lower = 0.01, upper = 0.02),
-    paradox::ParamInt$new("minsplit", lower = 1, upper = 2))))
+  "ml_g" = paradox::ps(
+    cp = paradox::p_dbl(lower = 0.01, upper = 0.02),
+    minsplit = paradox::p_int(lower = 1, upper = 2)),
+  "ml_m" = paradox::ps(
+    cp = paradox::p_dbl(lower = 0.01, upper = 0.02),
+    minsplit = paradox::p_int(lower = 1, upper = 2)))
 
 # minimum requirements for tune_settings
 tune_settings = list(

--- a/man/DoubleMLPLIV.Rd
+++ b/man/DoubleMLPLIV.Rd
@@ -49,15 +49,15 @@ obj_dml_data = make_pliv_CHS2015(
   dim_z = 1)
 dml_pliv_obj = DoubleMLPLIV$new(obj_dml_data, ml_l, ml_m, ml_r)
 param_grid = list(
-  "ml_l" = paradox::ParamSet$new(list(
-    paradox::ParamDbl$new("cp", lower = 0.01, upper = 0.02),
-    paradox::ParamInt$new("minsplit", lower = 1, upper = 2))),
-  "ml_m" = paradox::ParamSet$new(list(
-    paradox::ParamDbl$new("cp", lower = 0.01, upper = 0.02),
-    paradox::ParamInt$new("minsplit", lower = 1, upper = 2))),
-  "ml_r" = paradox::ParamSet$new(list(
-    paradox::ParamDbl$new("cp", lower = 0.01, upper = 0.02),
-    paradox::ParamInt$new("minsplit", lower = 1, upper = 2))))
+  "ml_l" = paradox::ps(
+    cp = paradox::p_dbl(lower = 0.01, upper = 0.02),
+    minsplit = paradox::p_int(lower = 1, upper = 2)),
+  "ml_m" = paradox::ps(
+    cp = paradox::p_dbl(lower = 0.01, upper = 0.02),
+    minsplit = paradox::p_int(lower = 1, upper = 2)),
+  "ml_r" = paradox::ps(
+    cp = paradox::p_dbl(lower = 0.01, upper = 0.02),
+    minsplit = paradox::p_int(lower = 1, upper = 2)))
 
 # minimum requirements for tune_settings
 tune_settings = list(

--- a/man/DoubleMLPLR.Rd
+++ b/man/DoubleMLPLR.Rd
@@ -49,12 +49,12 @@ obj_dml_data = make_plr_CCDDHNR2018(alpha = 0.5)
 dml_plr_obj = DoubleMLPLR$new(obj_dml_data, ml_l, ml_m)
 
 param_grid = list(
-  "ml_l" = paradox::ParamSet$new(list(
-    paradox::ParamDbl$new("cp", lower = 0.01, upper = 0.02),
-    paradox::ParamInt$new("minsplit", lower = 1, upper = 2))),
-  "ml_m" = paradox::ParamSet$new(list(
-    paradox::ParamDbl$new("cp", lower = 0.01, upper = 0.02),
-    paradox::ParamInt$new("minsplit", lower = 1, upper = 2))))
+  "ml_l" = paradox::ps(
+    cp = paradox::p_dbl(lower = 0.01, upper = 0.02),
+    minsplit = paradox::p_int(lower = 1, upper = 2)),
+  "ml_m" = paradox::ps(
+    cp = paradox::p_dbl(lower = 0.01, upper = 0.02),
+    minsplit = paradox::p_int(lower = 1, upper = 2)))
 
 # minimum requirements for tune_settings
 tune_settings = list(

--- a/tests/testthat/test-double_ml_iivm_tuning.R
+++ b/tests/testthat/test-double_ml_iivm_tuning.R
@@ -63,15 +63,15 @@ patrick::with_parameters_test_that("Unit tests for tuning of IIVM:",
       n_rep = n_rep)
 
     param_grid = list(
-      "ml_m" = paradox::ParamSet$new(list(
-        paradox::ParamDbl$new("cp", lower = 0.01, upper = 0.02),
-        paradox::ParamInt$new("minsplit", lower = 1, upper = 2))),
-      "ml_g" = paradox::ParamSet$new(list(
-        paradox::ParamDbl$new("cp", lower = 0.01, upper = 0.02),
-        paradox::ParamInt$new("minsplit", lower = 1, upper = 2))),
-      "ml_r" = paradox::ParamSet$new(list(
-        paradox::ParamDbl$new("cp", lower = 0.01, upper = 0.02),
-        paradox::ParamInt$new("minsplit", lower = 1, upper = 2))))
+      "ml_m" = paradox::ps(
+        cp = paradox::p_dbl(lower = 0.01, upper = 0.02),
+        minsplit = paradox::p_int(lower = 1, upper = 2)),
+      "ml_g" = paradox::ps(
+        cp = paradox::p_dbl(lower = 0.01, upper = 0.02),
+        minsplit = paradox::p_int(lower = 1, upper = 2)),
+      "ml_r" = paradox::ps(
+        cp = paradox::p_dbl(lower = 0.01, upper = 0.02),
+        minsplit = paradox::p_int(lower = 1, upper = 2)))
 
     double_mliivm_obj_tuned$tune(param_set = param_grid, tune_on_folds = tune_on_folds, tune_settings = tune_settings)
     double_mliivm_obj_tuned$fit()

--- a/tests/testthat/test-double_ml_irm_tuning.R
+++ b/tests/testthat/test-double_ml_irm_tuning.R
@@ -66,12 +66,12 @@ patrick::with_parameters_test_that("Unit tests for tuning of PLR:",
       score = score)
 
     param_grid = list(
-      "ml_g" = paradox::ParamSet$new(list(
-        paradox::ParamDbl$new("cp", lower = 0.01, upper = 0.02),
-        paradox::ParamInt$new("minsplit", lower = 1, upper = 2))),
-      "ml_m" = paradox::ParamSet$new(list(
-        paradox::ParamDbl$new("cp", lower = 0.01, upper = 0.02),
-        paradox::ParamInt$new("minsplit", lower = 1, upper = 2))))
+      "ml_g" = paradox::ps(
+        cp = paradox::p_dbl(lower = 0.01, upper = 0.02),
+        minsplit = paradox::p_int(lower = 1, upper = 2)),
+      "ml_m" = paradox::ps(
+        cp = paradox::p_dbl(lower = 0.01, upper = 0.02),
+        minsplit = paradox::p_int(lower = 1, upper = 2)))
 
     double_mlirm_obj_tuned$tune(param_set = param_grid, tune_on_folds = tune_on_folds, tune_settings)
     double_mlirm_obj_tuned$fit()

--- a/tests/testthat/test-double_ml_pliv_exception_handling.R
+++ b/tests/testthat/test-double_ml_pliv_exception_handling.R
@@ -35,12 +35,12 @@ test_that("Unit tests for deprecation warnings of PLIV", {
   regexp = msg)
 
   par_grids = list(
-    "ml_g" = paradox::ParamSet$new(list(
-      paradox::ParamInt$new("num.trees", lower = 9, upper = 10))),
-    "ml_m" = paradox::ParamSet$new(list(
-      paradox::ParamInt$new("num.trees", lower = 10, upper = 11))),
-    "ml_r" = paradox::ParamSet$new(list(
-      paradox::ParamInt$new("num.trees", lower = 10, upper = 11))))
+    "ml_g" = paradox::ps(
+      num.trees = paradox::p_int(lower = 9, upper = 10)),
+    "ml_m" = paradox::ps(
+      num.trees = paradox::p_int(lower = 10, upper = 11)),
+    "ml_r" = paradox::ps(
+      num.trees = paradox::p_int(lower = 10, upper = 11)))
 
   msg = paste0("Learner ml_g was renamed to ml_l.")
   expect_warning(dml_obj$tune(par_grids),

--- a/tests/testthat/test-double_ml_pliv_tuning.R
+++ b/tests/testthat/test-double_ml_pliv_tuning.R
@@ -79,19 +79,19 @@ patrick::with_parameters_test_that("Unit tests for tuning of PLIV",
       n_rep = n_rep)
 
     param_grid = list(
-      "ml_l" = paradox::ParamSet$new(list(
-        paradox::ParamDbl$new("cp", lower = 0.01, upper = 0.02),
-        paradox::ParamInt$new("minsplit", lower = 1, upper = 2))),
-      "ml_m" = paradox::ParamSet$new(list(
-        paradox::ParamDbl$new("cp", lower = 0.01, upper = 0.02),
-        paradox::ParamInt$new("minsplit", lower = 1, upper = 2))),
-      "ml_r" = paradox::ParamSet$new(list(
-        paradox::ParamDbl$new("cp", lower = 0.01, upper = 0.02),
-        paradox::ParamInt$new("minsplit", lower = 1, upper = 2))))
+      "ml_l" = paradox::ps(
+        cp = paradox::p_dbl(lower = 0.01, upper = 0.02),
+        minsplit = paradox::p_int(lower = 1, upper = 2)),
+      "ml_m" = paradox::ps(
+        cp = paradox::p_dbl(lower = 0.01, upper = 0.02),
+        minsplit = paradox::p_int(lower = 1, upper = 2)),
+      "ml_r" = paradox::ps(
+        cp = paradox::p_dbl(lower = 0.01, upper = 0.02),
+        minsplit = paradox::p_int(lower = 1, upper = 2)))
     if (score == "IV-type") {
-      param_grid[["ml_g"]] = paradox::ParamSet$new(list(
-        paradox::ParamDbl$new("cp", lower = 0.01, upper = 0.02),
-        paradox::ParamInt$new("minsplit", lower = 1, upper = 2)))
+      param_grid[["ml_g"]] = paradox::ps(
+        cp = paradox::p_dbl(lower = 0.01, upper = 0.02),
+        minsplit = paradox::p_int(lower = 1, upper = 2))
       tune_settings[["measure"]][["ml_g"]] = "regr.mse"
     }
 
@@ -175,15 +175,15 @@ patrick::with_parameters_test_that("Unit tests for tuning of PLIV (multiple Z)",
       n_rep = n_rep)
 
     param_grid = list(
-      "ml_l" = paradox::ParamSet$new(list(
-        paradox::ParamDbl$new("cp", lower = 0.01, upper = 0.02),
-        paradox::ParamInt$new("minsplit", lower = 1, upper = 2))),
-      "ml_m" = paradox::ParamSet$new(list(
-        paradox::ParamDbl$new("cp", lower = 0.01, upper = 0.02),
-        paradox::ParamInt$new("minsplit", lower = 1, upper = 2))),
-      "ml_r" = paradox::ParamSet$new(list(
-        paradox::ParamDbl$new("cp", lower = 0.01, upper = 0.02),
-        paradox::ParamInt$new("minsplit", lower = 1, upper = 2))))
+      "ml_l" = paradox::ps(
+        cp = paradox::p_dbl(lower = 0.01, upper = 0.02),
+        minsplit = paradox::p_int(lower = 1, upper = 2)),
+      "ml_m" = paradox::ps(
+        cp = paradox::p_dbl(lower = 0.01, upper = 0.02),
+        minsplit = paradox::p_int(lower = 1, upper = 2)),
+      "ml_r" = paradox::ps(
+        cp = paradox::p_dbl(lower = 0.01, upper = 0.02),
+        minsplit = paradox::p_int(lower = 1, upper = 2)))
 
     double_mlpliv_obj_tuned$tune(param_set = param_grid, tune_settings = tune_settings, tune_on_folds = tune_on_folds)
     double_mlpliv_obj_tuned$fit()

--- a/tests/testthat/test-double_ml_plr_exception_handling.R
+++ b/tests/testthat/test-double_ml_plr_exception_handling.R
@@ -167,10 +167,10 @@ test_that("Unit tests for deprecation warnings of PLR", {
   regexp = msg)
 
   par_grids = list(
-    "ml_g" = paradox::ParamSet$new(list(
-      paradox::ParamInt$new("num.trees", lower = 9, upper = 10))),
-    "ml_m" = paradox::ParamSet$new(list(
-      paradox::ParamInt$new("num.trees", lower = 10, upper = 11))))
+    "ml_g" = paradox::ps(
+      num.trees = paradox::p_int(lower = 9, upper = 10)),
+    "ml_m" = paradox::ps(
+      num.trees = paradox::p_int(lower = 10, upper = 11)))
 
   msg = paste0("Learner ml_g was renamed to ml_l.")
   expect_warning(dml_obj$tune(par_grids),

--- a/tests/testthat/test-double_ml_plr_tuning.R
+++ b/tests/testthat/test-double_ml_plr_tuning.R
@@ -79,17 +79,17 @@ patrick::with_parameters_test_that("Unit tests for tuning of PLR:",
       resolution = 5)
 
     param_grid = list(
-      "ml_l" = paradox::ParamSet$new(list(
-        paradox::ParamDbl$new("cp", lower = 0.02, upper = 0.03),
-        paradox::ParamInt$new("minsplit", lower = 1, upper = 2))),
-      "ml_m" = paradox::ParamSet$new(list(
-        paradox::ParamDbl$new("cp", lower = 0.03, upper = 0.04),
-        paradox::ParamInt$new("minsplit", lower = 2, upper = 3))))
+      "ml_l" = paradox::ps(
+        cp = paradox::p_dbl(lower = 0.02, upper = 0.03),
+        minsplit = paradox::p_int(lower = 1, upper = 2)),
+      "ml_m" = paradox::ps(
+        cp = paradox::p_dbl(lower = 0.03, upper = 0.04),
+        minsplit = paradox::p_int(lower = 2, upper = 3)))
 
     if (score == "IV-type") {
-      param_grid[["ml_g"]] = paradox::ParamSet$new(list(
-        paradox::ParamDbl$new("cp", lower = 0.015, upper = 0.025),
-        paradox::ParamInt$new("minsplit", lower = 3, upper = 4)))
+      param_grid[["ml_g"]] = paradox::ps(
+        cp = paradox::p_dbl(lower = 0.015, upper = 0.025),
+        minsplit = paradox::p_int(lower = 3, upper = 4))
     }
 
     double_mlplr_obj_tuned$tune(param_set = param_grid, tune_on_folds = tune_on_folds, tune_settings = tune_sets)


### PR DESCRIPTION
### Description

Use version-agnostic `paradox` UI to prepare for new CRAN release: Instead of `ParamDbl`, `ParamInt` objects, create `ParamSets` using `ps(param_id = p_int(...))`. 

### Reference to Issues or PRs

#194

### Comments

CI checks that use the 'dev' version of `mlr3` now also use the dev-version of `paradox`; you can choose to remove this once `paradox` 1.0.0 is on CRAN.

### PR Checklist
Please fill out this PR checklist (see our [contributing guidelines](https://github.com/DoubleML/doubleml-for-r/blob/main/CONTRIBUTING.md#checklist-for-pull-requests-pr) for details).

- [X] The title of the pull request summarizes the changes made.
- [X] The PR contains a detailed description of all changes and additions.
- [X] References to related issues or PRs are added.
- [X] The code passes `R CMD check` and all (unit) tests (see our [contributing guidelines](https://github.com/DoubleML/doubleml-for-r/blob/main/CONTRIBUTING.md#checklist-for-pull-requests-pr) for details).
- [X] Enhancements or new feature are equipped with unit tests.
- [X] The changes adhere to the "mlr-style" standards (see our [contributing guidelines](https://github.com/DoubleML/doubleml-for-r/blob/main/CONTRIBUTING.md#checklist-for-pull-requests-pr) for details).
