### PR TITLE
Bump required mlr3learners version

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -35,7 +35,7 @@ Imports:
     utils,
     clusterGeneration,
     readstata13,
-    mlr3learners (>= 0.3.0),
+    mlr3learners (>= 0.6.0),
     mlr3misc
 Roxygen: list(markdown = TRUE, r6 = TRUE)
 RoxygenNote: 7.3.1


### PR DESCRIPTION
I am not sure what version is actually required. I am just surfacing from an incredibly painful few weeks of intermittent debugging which finally resolved by updating {mlr3learners}.

Here's the type of stack trace I was dealing with 🫨 

```
── Error (test-double_ml_pliv_exception_handling.R:46:3): Unit tests for deprecation warnings of PLIV ──
Error in `predict.ranger.forest(forest, data, predict.all, num.trees, type, 
    se.method, seed, num.threads, verbose, object$inbag.counts, 
    ...)`: Error: One or more independent variables not found in data.
Backtrace:
     ▆
  1. ├─testthat::expect_warning(dml_obj$tune(par_grids), regexp = msg) at test-double_ml_pliv_exception_handling.R:46:3
  2. │ └─testthat:::quasi_capture(...)
  3. │   ├─testthat (local) .capture(...)
  4. │   │ └─base::withCallingHandlers(...)
  5. │   └─rlang::eval_bare(quo_get_expr(.quo), quo_get_env(.quo))
  6. └─dml_obj$tune(par_grids)
  7.   └─super$tune(param_set, tune_settings, tune_on_folds)
  8.     └─private$nuisance_tuning(...)
  9.       └─private$nuisance_tuning_partialX(...)
 10.         └─DoubleML:::dml_tune(...)
 11.           └─base::lapply(...)
 12.             └─DoubleML (local) FUN(X[[i]], ...)
 13.               └─DoubleML:::tune_instance(tune_settings$tuner, x)
 14.                 └─tuner$optimize(tuning_instance)
 15.                   └─mlr3tuning:::.__Tuner__optimize(...)
 16.                     └─bbotk::optimize_default(inst, self, private)
 17.                       ├─base::tryCatch(...)
 18.                       │ └─base (local) tryCatchList(expr, classes, parentenv, handlers)
 19.                       │   └─base (local) tryCatchOne(expr, names, parentenv, handlers[[1L]])
 20.                       │     └─base (local) doTryCatch(return(expr), name, parentenv, handler)
 21.                       └─private$.optimize(inst)
 22.                         └─mlr3tuning:::.__TunerGridSearch__.optimize(...)
 23.                           └─inst$eval_batch(data[inds])
 24.                             └─bbotk:::.__OptimInstance__eval_batch(...)
 25.                               └─self$objective$eval_many(xss_trafoed)
 26.                                 └─bbotk:::.__Objective__eval_many(...)
 27.                                   ├─mlr3misc::invoke(private$.eval_many, xss, .args = self$constants$values)
 28.                                   │ └─base::eval.parent(expr, n = 1L)
 29.                                   │   └─base::eval(expr, p)
 30.                                   │     └─base::eval(expr, p)
 31.                                   └─private$.eval_many(xss, resampling = `<list>`)
 32.                                     └─mlr3tuning:::.__ObjectiveTuning__.eval_many(...)
 33.                                       └─mlr3::benchmark(...)
 34.                                         └─mlr3:::future_map(...)
 35.                                           └─future.apply::future_mapply(...)
 36.                                             └─future.apply:::future_xapply(...)
 37.                                               ├─future::value(fs)
 38.                                               └─future:::value.list(fs)
 39.                                                 ├─future::resolve(...)
 40.                                                 └─future:::resolve.list(...)
 41.                                                   └─future (local) signalConditionsASAP(obj, resignal = FALSE, pos = ii)
 42.                                                     └─future:::signalConditions(...)
```

At root here is a problem with monorepos -- we typically update package versions only incrementally. I was trying to update data.table (1.14.x -> 1.15.5) and it led to a chain reaction of required updates, the end of which was this issue with an {mlr3learners} update being required deep in the stack of {DoubleML} tests.

All this to explain why I have not dived into what exact minimal version requirements solve the issue, an exercise for the reader 😉 